### PR TITLE
LIME-883: Updating access of the person identity mapper so we can use the person identity service in tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @govuk-one-login/cri-orange-team @govuk-one-login/cri-orange-admins @govuk-one-login/cri-lime-team-leads @govuk-one-login/identity-sre # Team ownership with break-glass overrides
+* @govuk-one-login/cri-orange-team @govuk-one-login/cri-orange-admins @govuk-one-login/cri-lime-team-leads @govuk-one-login/cri-lime-team-admins @govuk-one-login/identity-sre # Team ownership with break-glass overrides

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.5.4
+
+* Updated Person Identity Mapper access to public so it can be tested and mocked by other services that use the person identity service
+
 ## 1.5.3
 
 * Increased version number of nimbusds and awssdk dependencies to remove vulnerabilities, aligned tests to changes in the nimbus error message format

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.5.3"
+def buildVersion = "1.5.4"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapper.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapper.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-class PersonIdentityMapper {
+public class PersonIdentityMapper {
 
     private enum NamePartType {
         GIVEN_NAME("GivenName"),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Making package access public for the person identity mapper

### Why did it change

To allow testing in other services that use the common lib

