### PR TITLE
OJ-2240: prep add address vc restricted fields

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.5.5
+
+* Added `PersonIdentityDetailedBuilder` with similar intent as `PersonIdentityDetailedFactory` for constructing PersonIdentityDetailed with a builder constructor no args option
+* For cases where CRI's requires a PersonIdentityDetailed object without `nameparts` or `birthdate` for use with the `AuditContext`
+* `PersonIdentityDetailedBuilder` can be used as an alternative to `PersonIdentityDetailedFactory`
+
 ## 1.5.4
 
 * Updated Person Identity Mapper access to public so it can be tested and mocked by other services that use the person identity service

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.5.4"
+def buildVersion = "1.5.5"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/Address.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/Address.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.cri.common.library.domain.personidentity;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
 
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
@@ -24,6 +25,28 @@ public class Address {
     private String addressLocality;
     private String postalCode;
     private String addressCountry;
+
+    public Address() {
+        this(new CanonicalAddress());
+    }
+
+    public Address(CanonicalAddress address) {
+        this.uprn = address.getUprn();
+        this.organisationName = address.getOrganisationName();
+        this.departmentName = address.getDepartmentName();
+        this.subBuildingName = address.getSubBuildingName();
+        this.buildingNumber = address.getBuildingNumber();
+        this.buildingName = address.getBuildingName();
+        this.dependentStreetName = address.getDependentStreetName();
+        this.streetName = address.getStreetName();
+        this.doubleDependentAddressLocality = address.getDoubleDependentAddressLocality();
+        this.dependentAddressLocality = address.getDependentAddressLocality();
+        this.addressLocality = address.getAddressLocality();
+        this.postalCode = address.getPostalCode();
+        this.addressCountry = address.getAddressCountry();
+        this.validFrom = address.getValidFrom();
+        this.validUntil = address.getValidUntil();
+    }
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate validFrom;

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityDetailedBuilder.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityDetailedBuilder.java
@@ -1,0 +1,68 @@
+package uk.gov.di.ipv.cri.common.library.service;
+
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.BirthDate;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.DrivingPermit;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.Name;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.Passport;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
+
+import java.util.List;
+
+public class PersonIdentityDetailedBuilder {
+    /* Builder approach similar in intent to PersonIdentityDetailedFactory
+    A way of constructing PersonIdentityDetailed where some components are not needed
+    Avoids cris needing to provide null lists for parameters they don't need.
+    Avoids a growing chain of lists being added to the public constructor and also
+    useful in when used in conjunction with AuditContext to build out AuditEvent
+    where names, birthDates may be desirable as nulls
+    */
+    private PersonIdentityDetailedBuilder() {
+        throw new IllegalStateException("Instantiation is not valid for this class.");
+    }
+
+    public static Builder builder(List<Name> names, List<BirthDate> birthDates) {
+        return new Builder(names, birthDates);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private List<Name> names;
+        private List<BirthDate> birthDates;
+        private List<Address> addresses;
+        private List<DrivingPermit> drivingPermits;
+        private List<Passport> passports;
+
+        private Builder() {
+            this(null, null);
+        }
+
+        private Builder(List<Name> names, List<BirthDate> birthDates) {
+            this.names = names;
+            this.birthDates = birthDates;
+        }
+
+        public Builder withAddresses(List<Address> addresses) {
+            this.addresses = addresses;
+            return this;
+        }
+
+        public Builder withDrivingPermits(List<DrivingPermit> drivingPermits) {
+            this.drivingPermits = drivingPermits;
+            return this;
+        }
+
+        public Builder withPassports(List<Passport> passports) {
+            this.passports = passports;
+            return this;
+        }
+        @SuppressWarnings("deprecation")
+        public PersonIdentityDetailed build() {
+            return new PersonIdentityDetailed(
+                    names, birthDates, addresses, drivingPermits, passports);
+        }
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityDetailedBuilder.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityDetailedBuilder.java
@@ -59,6 +59,7 @@ public class PersonIdentityDetailedBuilder {
             this.passports = passports;
             return this;
         }
+
         @SuppressWarnings("deprecation")
         public PersonIdentityDetailed build() {
             return new PersonIdentityDetailed(

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapper.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapper.java
@@ -101,30 +101,7 @@ public class PersonIdentityMapper {
     }
 
     private List<Address> mapCanonicalAddresses(List<CanonicalAddress> addresses) {
-        return addresses.stream()
-                .map(
-                        address -> {
-                            Address mappedAddress = new Address();
-                            mappedAddress.setAddressCountry(address.getAddressCountry());
-                            mappedAddress.setAddressLocality(address.getAddressLocality());
-                            mappedAddress.setBuildingName(address.getBuildingName());
-                            mappedAddress.setBuildingNumber(address.getBuildingNumber());
-                            mappedAddress.setDepartmentName(address.getDepartmentName());
-                            mappedAddress.setDependentAddressLocality(
-                                    address.getDependentAddressLocality());
-                            mappedAddress.setDependentStreetName(address.getDependentStreetName());
-                            mappedAddress.setDoubleDependentAddressLocality(
-                                    address.getDoubleDependentAddressLocality());
-                            mappedAddress.setOrganisationName(address.getOrganisationName());
-                            mappedAddress.setPostalCode(address.getPostalCode());
-                            mappedAddress.setStreetName(address.getStreetName());
-                            mappedAddress.setSubBuildingName(address.getSubBuildingName());
-                            mappedAddress.setUprn(address.getUprn());
-                            mappedAddress.setValidFrom(address.getValidFrom());
-                            mappedAddress.setValidUntil(address.getValidUntil());
-                            return mappedAddress;
-                        })
-                .collect(Collectors.toList());
+        return addresses.stream().map(Address::new).collect(Collectors.toList());
     }
 
     private List<BirthDate> mapPersonIdentityBirthDates(

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityDetailedBuilderTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityDetailedBuilderTest.java
@@ -1,0 +1,168 @@
+package uk.gov.di.ipv.cri.common.library.service;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.BirthDate;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.DrivingPermit;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.Name;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.NamePart;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.Passport;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PersonIdentityDetailedBuilderTest {
+    @Nested
+    class BuilderWithNamesParts {
+        @Test
+        void shouldUseBuilderToCreatePersonIdentityDetailedWithDrivingPermit() {
+            NamePart firstNamePart = new NamePart();
+            firstNamePart.setType("GivenName");
+            firstNamePart.setValue("Jon");
+            NamePart surnamePart = new NamePart();
+            surnamePart.setType("FamilyName");
+            surnamePart.setValue("Smith");
+            Name name = new Name();
+            name.setNameParts(List.of(firstNamePart, surnamePart));
+            List<Name> names = List.of(name);
+
+            LocalDate dob = LocalDate.of(1984, 6, 27);
+            BirthDate birthDate = new BirthDate();
+            birthDate.setValue(dob);
+            List<BirthDate> birthDates = List.of(birthDate);
+
+            // DP address is just postcode
+            Address address = new Address();
+            address.setPostalCode("postcode");
+            List<Address> addresses = List.of(address);
+
+            DrivingPermit drivingPermit = new DrivingPermit();
+            drivingPermit.setPersonalNumber("123456789");
+            drivingPermit.setIssueDate(dob.plus(18, ChronoUnit.YEARS).toString());
+            drivingPermit.setExpiryDate(LocalDate.now().plus(10, ChronoUnit.YEARS).toString());
+            drivingPermit.setIssuedBy("DVLA");
+            drivingPermit.setIssueNumber("1");
+            List<DrivingPermit> drivingPermits = List.of(drivingPermit);
+
+            PersonIdentityDetailed personIdentityDetailed =
+                    PersonIdentityDetailedBuilder.builder(names, birthDates)
+                            .withAddresses(addresses)
+                            .withDrivingPermits(drivingPermits)
+                            .build();
+
+            assertEquals(names, personIdentityDetailed.getNames());
+            assertEquals(
+                    firstNamePart.getValue(),
+                    personIdentityDetailed.getNames().get(0).getNameParts().get(0).getValue());
+            assertEquals(
+                    surnamePart.getValue(),
+                    personIdentityDetailed.getNames().get(0).getNameParts().get(1).getValue());
+
+            assertEquals(birthDates, personIdentityDetailed.getBirthDates());
+            assertEquals(
+                    birthDate.getValue(), personIdentityDetailed.getBirthDates().get(0).getValue());
+
+            Address pidAddress = personIdentityDetailed.getAddresses().get(0);
+            assertEquals(addresses, personIdentityDetailed.getAddresses());
+            assertEquals(address.getPostalCode(), pidAddress.getPostalCode());
+
+            assertEquals(drivingPermits, personIdentityDetailed.getDrivingPermits());
+
+            DrivingPermit pidDrivingPermit = personIdentityDetailed.getDrivingPermits().get(0);
+            assertEquals(drivingPermit.getPersonalNumber(), pidDrivingPermit.getPersonalNumber());
+            assertEquals(drivingPermit.getIssueDate(), pidDrivingPermit.getIssueDate());
+            assertEquals(drivingPermit.getExpiryDate(), pidDrivingPermit.getExpiryDate());
+            assertEquals(drivingPermit.getIssuedBy(), pidDrivingPermit.getIssuedBy());
+            assertEquals(drivingPermit.getIssueNumber(), pidDrivingPermit.getIssueNumber());
+
+            assertNull(personIdentityDetailed.getPassports());
+        }
+
+        @Test
+        void shouldUseBuilderToCreatePersonIdentityWithPassport() {
+            NamePart firstNamePart = new NamePart();
+            firstNamePart.setType("GivenName");
+            firstNamePart.setValue("Jon");
+            NamePart surnamePart = new NamePart();
+            surnamePart.setType("FamilyName");
+            surnamePart.setValue("Smith");
+            Name name = new Name();
+            name.setNameParts(List.of(firstNamePart, surnamePart));
+            List<Name> names = List.of(name);
+
+            LocalDate dob = LocalDate.of(1984, 6, 27);
+            BirthDate birthDate = new BirthDate();
+            birthDate.setValue(dob);
+            List<BirthDate> birthDates = List.of(birthDate);
+
+            Passport passport = new Passport();
+            passport.setDocumentNumber("123456789");
+            passport.setExpiryDate(LocalDate.now().plus(10, ChronoUnit.YEARS).toString());
+            passport.setIcaoIssuerCode("GBR");
+            List<Passport> passports = List.of(passport);
+
+            PersonIdentityDetailed personIdentityDetailed =
+                    PersonIdentityDetailedBuilder.builder(names, birthDates)
+                            .withPassports(passports)
+                            .build();
+
+            assertEquals(names, personIdentityDetailed.getNames());
+            assertEquals(
+                    firstNamePart.getValue(),
+                    personIdentityDetailed.getNames().get(0).getNameParts().get(0).getValue());
+            assertEquals(
+                    surnamePart.getValue(),
+                    personIdentityDetailed.getNames().get(0).getNameParts().get(1).getValue());
+
+            assertEquals(birthDates, personIdentityDetailed.getBirthDates());
+            assertEquals(
+                    birthDate.getValue(), personIdentityDetailed.getBirthDates().get(0).getValue());
+
+            Passport pidPassport = personIdentityDetailed.getPassports().get(0);
+            assertEquals(passports, personIdentityDetailed.getPassports());
+            assertEquals(passport.getDocumentNumber(), pidPassport.getDocumentNumber());
+            assertEquals(passport.getExpiryDate(), pidPassport.getExpiryDate());
+            assertEquals(passport.getIcaoIssuerCode(), pidPassport.getIcaoIssuerCode());
+
+            assertNull(personIdentityDetailed.getAddresses());
+            assertNull(personIdentityDetailed.getDrivingPermits());
+        }
+    }
+
+    @Nested
+    class BuilderWithoutNamesParts {
+        @Test
+        void shouldUseBuilderToCreatePersonIdentityDetailedWithAddresses() {
+            Address address = new Address();
+            address.setBuildingNumber("buildingNum");
+            address.setBuildingName("buildingName");
+            address.setStreetName("street");
+            address.setAddressLocality("locality");
+            address.setPostalCode("postcode");
+            address.setValidFrom(LocalDate.now());
+
+            List<Address> addresses = List.of(address);
+            PersonIdentityDetailed personIdentityDetailed =
+                    PersonIdentityDetailedBuilder.builder().withAddresses(addresses).build();
+
+            Address pidAddress = personIdentityDetailed.getAddresses().get(0);
+            assertEquals(addresses, personIdentityDetailed.getAddresses());
+            assertEquals(address.getBuildingName(), pidAddress.getBuildingName());
+            assertEquals(address.getBuildingNumber(), pidAddress.getBuildingNumber());
+            assertEquals(address.getStreetName(), pidAddress.getStreetName());
+            assertEquals(address.getAddressLocality(), pidAddress.getAddressLocality());
+            assertEquals(address.getPostalCode(), pidAddress.getPostalCode());
+            assertEquals(address.getValidFrom(), pidAddress.getValidFrom());
+            assertEquals(AddressType.CURRENT, pidAddress.getAddressType());
+
+            assertNull(personIdentityDetailed.getDrivingPermits());
+            assertNull(personIdentityDetailed.getPassports());
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

see https://github.com/govuk-one-login/ipv-cri-address-api/pull/885

### Why did it change

Added a constructor to Address Domain object to allow, converting to from CanonicalAddress to Address
This is done to avoid using the PersonIdentityMapper

Also added Added `PersonIdentityDetailedBuilder` to be used with the AuditContext for AddressCri where
nameparts and birthdate are not required and would have required passing nulls as follows

**Before**
```
 new AuditEventContext(
                            new PersonIdentityDetailed(
                                    null,
                                    null,
                                    addressService.mapCanonicalAddresses(
                                            addressItem.getAddresses()))
```

`After`
```
new AuditEventContext(
                        PersonIdentityDetailedBuilder.builder()
                                .withAddresses(
                                        addressItem.getAddresses().stream()
                                                .map(Address::new)
                                                .collect(Collectors.toList()))
                                .build())
```

- [OJ-2240](https://govukverify.atlassian.net/browse/OJ-2240)

[OJ-2240]: https://govukverify.atlassian.net/browse/OJ-2240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ