### PR TITLE
LIME-1019 - Amending audit event timestamps to be in milliseconds

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.5.6
+
+* Updated AuditEventFactory to create timestamps in milliseconds for audit events
+
 ## 1.5.5
 
 * Added `PersonIdentityDetailedBuilder` with similar intent as `PersonIdentityDetailedFactory` for constructing PersonIdentityDetailed with a builder constructor no args option

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.5.5"
+def buildVersion = "1.5.6"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEvent.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEvent.java
@@ -11,6 +11,9 @@ public class AuditEvent<T> {
     @JsonProperty("timestamp")
     private final long timestamp;
 
+    @JsonProperty("event_timestamp_ms")
+    private final long eventTimestampMs;
+
     @JsonProperty("event_name")
     private final String event;
 
@@ -24,9 +27,11 @@ public class AuditEvent<T> {
     @JsonCreator
     public AuditEvent(
             @JsonProperty(value = "timestamp", required = true) long timestamp,
+            @JsonProperty(value = "event_timestamp_ms", required = true) long eventTimestampMs,
             @JsonProperty(value = "event_name", required = true) String event,
             @JsonProperty(value = "component_id", required = true) String issuer) {
         this.timestamp = timestamp;
+        this.eventTimestampMs = eventTimestampMs;
         this.event = event;
         this.issuer = issuer;
     }
@@ -36,6 +41,8 @@ public class AuditEvent<T> {
         return "AuditEvent{"
                 + "timestamp="
                 + timestamp
+                + ", event_timestamp_ms="
+                + eventTimestampMs
                 + ", event="
                 + event
                 + ", component_id="
@@ -45,6 +52,10 @@ public class AuditEvent<T> {
 
     public long getTimestamp() {
         return timestamp;
+    }
+
+    public long getEventTimestampMs() {
+        return eventTimestampMs;
     }
 
     public String getEvent() {

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactory.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactory.java
@@ -33,7 +33,10 @@ public class AuditEventFactory {
     <T> AuditEvent<T> create(String eventType, AuditEventContext auditEventContext, T extensions) {
         AuditEvent<T> auditEvent =
                 new AuditEvent<>(
-                        clock.instant().getEpochSecond(), eventPrefix + "_" + eventType, issuer);
+                        clock.instant().getEpochSecond(),
+                        clock.instant().toEpochMilli(),
+                        eventPrefix + "_" + eventType,
+                        issuer);
         if (Objects.nonNull(auditEventContext)) {
             if (Objects.nonNull(auditEventContext.getPersonIdentity())) {
                 auditEvent.setRestricted(auditEventContext.getPersonIdentity());

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactoryTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactoryTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -66,6 +67,7 @@ class AuditEventFactoryTest {
     @Test
     void shouldCreateAuditEventWithContextAndExtensions() {
         long timestamp = 1656947224L;
+        long eventTimestampMs = 165694722422L;
         String userId = String.valueOf(UUID.randomUUID());
         UUID sessionId = UUID.randomUUID();
         String persistentSessionId = UUID.randomUUID().toString();
@@ -75,6 +77,7 @@ class AuditEventFactoryTest {
         when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_VC_ISSUER);
         Instant mockInstant = mock(Instant.class);
         when(mockInstant.getEpochSecond()).thenReturn(timestamp);
+        when(mockInstant.toEpochMilli()).thenReturn(eventTimestampMs);
         when(mockClock.instant()).thenReturn(mockInstant);
         PersonIdentityDetailed personIdentity = mock(PersonIdentityDetailed.class);
         Map<String, String> requestHeaders = Map.of("X-Forwarded-For", clientIpAddress);
@@ -95,6 +98,7 @@ class AuditEventFactoryTest {
         assertEquals(TEST_AUDIT_EVENT_PREFIX + "_EVENT_TYPE", auditEvent.getEvent());
         assertEquals(personIdentity, auditEvent.getRestricted());
         assertEquals(timestamp, auditEvent.getTimestamp());
+        assertEquals(eventTimestampMs, auditEvent.getEventTimestampMs());
         assertEquals(userId, auditEvent.getUser().getUserId());
         assertEquals(clientIpAddress, auditEvent.getUser().getIpAddress());
         assertEquals(String.valueOf(sessionId), auditEvent.getUser().getSessionId());
@@ -103,8 +107,8 @@ class AuditEventFactoryTest {
 
         assertEquals(auditEventExtensions, auditEvent.getExtensions());
 
-        verify(mockClock).instant();
-        verify(mockInstant).getEpochSecond();
+        verify(mockClock, times(2)).instant();
+        verify(mockInstant).toEpochMilli();
         verify(mockConfigurationService).getSqsAuditEventPrefix();
         verify(mockConfigurationService).getVerifiableCredentialIssuer();
     }
@@ -112,11 +116,13 @@ class AuditEventFactoryTest {
     @Test
     void shouldCreateAuditEventWithContext() {
         long timestamp = 1656947224L;
+        long eventTimestampMs = 165694722422L;
         String clientIpAddress = "81.145.61.43";
         when(mockConfigurationService.getSqsAuditEventPrefix()).thenReturn(TEST_AUDIT_EVENT_PREFIX);
         when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_VC_ISSUER);
         Instant mockInstant = mock(Instant.class);
         when(mockInstant.getEpochSecond()).thenReturn(timestamp);
+        when(mockInstant.toEpochMilli()).thenReturn(eventTimestampMs);
         when(mockClock.instant()).thenReturn(mockInstant);
         PersonIdentityDetailed personIdentity = mock(PersonIdentityDetailed.class);
         Map<String, String> requestHeaders = Map.of("X-Forwarded-For", clientIpAddress);
@@ -131,6 +137,7 @@ class AuditEventFactoryTest {
         assertEquals(TEST_AUDIT_EVENT_PREFIX + "_EVENT_TYPE", auditEvent.getEvent());
         assertEquals(personIdentity, auditEvent.getRestricted());
         assertEquals(timestamp, auditEvent.getTimestamp());
+        assertEquals(eventTimestampMs, auditEvent.getEventTimestampMs());
         assertEquals(clientIpAddress, auditEvent.getUser().getIpAddress());
         assertNull(auditEvent.getUser().getUserId());
         assertNull(auditEvent.getUser().getSessionId());


### PR DESCRIPTION
### What changed
Amended audit event timestamps to now reflect milliseconds as requested from TxMA