### PR TITLE
DCP-3351: Adds device_information  to restricted if the header is present

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.6.0
+
+* Append `device_information` to `restricted` if the `txma-audit-encoded` header is present
+
 ## 1.5.6
 
 * Updated AuditEventFactory to create timestamps in milliseconds for audit events

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.5.6"
+def buildVersion = "1.6.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/DeviceInformation.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/DeviceInformation.java
@@ -1,0 +1,18 @@
+package uk.gov.di.ipv.cri.common.library.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DeviceInformation {
+    @JsonProperty(value = "encoded")
+    private String encoded;
+
+    public String getEncoded() {
+        return encoded;
+    }
+
+    public void setEncoded(String encoded) {
+        this.encoded = encoded;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/PersonIdentityDetailed.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/PersonIdentityDetailed.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.cri.common.library.domain.personidentity;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.ipv.cri.common.library.domain.DeviceInformation;
@@ -7,6 +8,7 @@ import uk.gov.di.ipv.cri.common.library.domain.DeviceInformation;
 import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PersonIdentityDetailed {
     @JsonProperty("name")
     private final List<Name> names;

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/PersonIdentityDetailed.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/PersonIdentityDetailed.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.cri.common.library.domain.personidentity;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.ipv.cri.common.library.domain.DeviceInformation;
 
 import java.util.List;
 
@@ -21,6 +22,9 @@ public class PersonIdentityDetailed {
 
     @JsonProperty("passport")
     private final List<Passport> passports;
+
+    @JsonProperty("device_information")
+    private DeviceInformation deviceInformation;
 
     /**
      * @param names list of names
@@ -93,5 +97,13 @@ public class PersonIdentityDetailed {
 
     public List<Passport> getPassports() {
         return passports;
+    }
+
+    public DeviceInformation getDeviceInformation() {
+        return deviceInformation;
+    }
+
+    public void setDeviceInformation(DeviceInformation deviceInformation) {
+        this.deviceInformation = deviceInformation;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactory.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactory.java
@@ -44,7 +44,7 @@ public class AuditEventFactory {
             Map<String, String> requestHeaders = auditEventContext.getRequestHeaders();
 
             auditEvent.setRestricted(
-                    createAuditEventResricted(
+                    createAuditEventRestricted(
                             requestHeaders, auditEventContext.getPersonIdentity()));
 
             auditEvent.setUser(
@@ -57,19 +57,9 @@ public class AuditEventFactory {
     }
 
     @SuppressWarnings("deprecation")
-    private PersonIdentityDetailed createAuditEventResricted(
+    private PersonIdentityDetailed createAuditEventRestricted(
             Map<String, String> requestHeaders, PersonIdentityDetailed personIdentityDetails) {
-        PersonIdentityDetailed restricted = null;
-
-        if (Objects.nonNull(personIdentityDetails)) {
-            restricted =
-                    new PersonIdentityDetailed(
-                            personIdentityDetails.getNames(),
-                            personIdentityDetails.getBirthDates(),
-                            personIdentityDetails.getAddresses(),
-                            personIdentityDetails.getDrivingPermits(),
-                            personIdentityDetails.getPassports());
-        }
+        PersonIdentityDetailed restricted = personIdentityDetails;
 
         if (requestHeaders.containsKey(TXMA_AUDIT_ENCODED)) {
             if (Objects.isNull(restricted)) {

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactory.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactory.java
@@ -4,6 +4,8 @@ import com.nimbusds.oauth2.sdk.util.StringUtils;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEvent;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventContext;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventUser;
+import uk.gov.di.ipv.cri.common.library.domain.DeviceInformation;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
 import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 
 import java.time.Clock;
@@ -12,6 +14,7 @@ import java.util.Objects;
 
 public class AuditEventFactory {
     private static final String CLIENT_IP_HEADER_KEY = "X-Forwarded-For";
+    private static final String TXMA_AUDIT_ENCODED = "txma-audit-encoded";
 
     private final String eventPrefix;
     private final String issuer;
@@ -38,18 +41,46 @@ public class AuditEventFactory {
                         eventPrefix + "_" + eventType,
                         issuer);
         if (Objects.nonNull(auditEventContext)) {
-            if (Objects.nonNull(auditEventContext.getPersonIdentity())) {
-                auditEvent.setRestricted(auditEventContext.getPersonIdentity());
-            }
+            Map<String, String> requestHeaders = auditEventContext.getRequestHeaders();
+
+            auditEvent.setRestricted(
+                    createAuditEventResricted(
+                            requestHeaders, auditEventContext.getPersonIdentity()));
+
             auditEvent.setUser(
-                    createAuditEventUser(
-                            auditEventContext.getRequestHeaders(),
-                            auditEventContext.getSessionItem()));
+                    createAuditEventUser(requestHeaders, auditEventContext.getSessionItem()));
         }
         if (Objects.nonNull(extensions)) {
             auditEvent.setExtensions(extensions);
         }
         return auditEvent;
+    }
+
+    @SuppressWarnings("deprecation")
+    private PersonIdentityDetailed createAuditEventResricted(
+            Map<String, String> requestHeaders, PersonIdentityDetailed personIdentityDetails) {
+        PersonIdentityDetailed restricted = null;
+
+        if (Objects.nonNull(personIdentityDetails)) {
+            restricted =
+                    new PersonIdentityDetailed(
+                            personIdentityDetails.getNames(),
+                            personIdentityDetails.getBirthDates(),
+                            personIdentityDetails.getAddresses(),
+                            personIdentityDetails.getDrivingPermits(),
+                            personIdentityDetails.getPassports());
+        }
+
+        if (requestHeaders.containsKey(TXMA_AUDIT_ENCODED)) {
+            if (Objects.isNull(restricted)) {
+                restricted = new PersonIdentityDetailed(null, null, null, null, null);
+            }
+            DeviceInformation deviceInformation = new DeviceInformation();
+            deviceInformation.setEncoded(requestHeaders.get(TXMA_AUDIT_ENCODED));
+            restricted.setDeviceInformation(deviceInformation);
+        }
+
+        return restricted;
     }
 
     private AuditEventUser createAuditEventUser(

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactoryTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactoryTest.java
@@ -99,6 +99,129 @@ class AuditEventFactoryTest {
         List<BirthDate> birthDates = List.of(birthDate);
         @SuppressWarnings("deprecation")
         PersonIdentityDetailed personIdentity = new PersonIdentityDetailed(names, birthDates);
+
+        Map<String, String> requestHeaders = Map.of("X-Forwarded-For", clientIpAddress);
+        SessionItem sessionItem = mock(SessionItem.class);
+        when(sessionItem.getSubject()).thenReturn(userId);
+        when(sessionItem.getSessionId()).thenReturn(sessionId);
+        when(sessionItem.getPersistentSessionId()).thenReturn(persistentSessionId);
+        when(sessionItem.getClientSessionId()).thenReturn(clientSessionId);
+        AuditEventContext auditEventContext =
+                new AuditEventContext(personIdentity, requestHeaders, sessionItem);
+        AuditEventFactory auditEventFactory =
+                new AuditEventFactory(mockConfigurationService, mockClock);
+        Map<String, String> auditEventExtensions = Map.of("test", "extension-data");
+
+        AuditEvent<Object> auditEvent =
+                auditEventFactory.create("EVENT_TYPE", auditEventContext, auditEventExtensions);
+
+        assertEquals(TEST_AUDIT_EVENT_PREFIX + "_EVENT_TYPE", auditEvent.getEvent());
+        assertEquals(names, auditEvent.getRestricted().getNames());
+        assertEquals(birthDates, auditEvent.getRestricted().getBirthDates());
+        assertEquals(timestamp, auditEvent.getTimestamp());
+        assertEquals(eventTimestampMs, auditEvent.getEventTimestampMs());
+        assertEquals(userId, auditEvent.getUser().getUserId());
+        assertEquals(clientIpAddress, auditEvent.getUser().getIpAddress());
+        assertEquals(String.valueOf(sessionId), auditEvent.getUser().getSessionId());
+        assertEquals(persistentSessionId, auditEvent.getUser().getPersistentSessionId());
+        assertEquals(clientSessionId, auditEvent.getUser().getClientSessionId());
+
+        assertEquals(auditEventExtensions, auditEvent.getExtensions());
+
+        verify(mockClock, times(2)).instant();
+        verify(mockInstant).toEpochMilli();
+        verify(mockConfigurationService).getSqsAuditEventPrefix();
+        verify(mockConfigurationService).getVerifiableCredentialIssuer();
+    }
+
+    @Test
+    void shouldCreateAuditEventWithContextAndDeviceInfoRestricted() {
+        long timestamp = 1656947224L;
+        long eventTimestampMs = 165694722422L;
+        String userId = String.valueOf(UUID.randomUUID());
+        UUID sessionId = UUID.randomUUID();
+        String persistentSessionId = UUID.randomUUID().toString();
+        String clientSessionId = UUID.randomUUID().toString();
+        String clientIpAddress = "81.145.61.43";
+        when(mockConfigurationService.getSqsAuditEventPrefix()).thenReturn(TEST_AUDIT_EVENT_PREFIX);
+        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_VC_ISSUER);
+        Instant mockInstant = mock(Instant.class);
+        when(mockInstant.getEpochSecond()).thenReturn(timestamp);
+        when(mockInstant.toEpochMilli()).thenReturn(eventTimestampMs);
+        when(mockClock.instant()).thenReturn(mockInstant);
+        String encodedDeviceInformation = "123456789";
+
+        Map<String, String> requestHeaders =
+                Map.of(
+                        "X-Forwarded-For",
+                        clientIpAddress,
+                        "txma-audit-encoded",
+                        encodedDeviceInformation);
+        SessionItem sessionItem = mock(SessionItem.class);
+        when(sessionItem.getSubject()).thenReturn(userId);
+        when(sessionItem.getSessionId()).thenReturn(sessionId);
+        when(sessionItem.getPersistentSessionId()).thenReturn(persistentSessionId);
+        when(sessionItem.getClientSessionId()).thenReturn(clientSessionId);
+        AuditEventContext auditEventContext = new AuditEventContext(requestHeaders, sessionItem);
+        AuditEventFactory auditEventFactory =
+                new AuditEventFactory(mockConfigurationService, mockClock);
+        Map<String, String> auditEventExtensions = Map.of("test", "extension-data");
+
+        AuditEvent<Object> auditEvent =
+                auditEventFactory.create("EVENT_TYPE", auditEventContext, auditEventExtensions);
+
+        assertEquals(TEST_AUDIT_EVENT_PREFIX + "_EVENT_TYPE", auditEvent.getEvent());
+        assertNull(auditEvent.getRestricted().getNames());
+        assertNull(auditEvent.getRestricted().getBirthDates());
+        assertEquals(
+                encodedDeviceInformation,
+                auditEvent.getRestricted().getDeviceInformation().getEncoded());
+        assertEquals(timestamp, auditEvent.getTimestamp());
+        assertEquals(eventTimestampMs, auditEvent.getEventTimestampMs());
+        assertEquals(userId, auditEvent.getUser().getUserId());
+        assertEquals(clientIpAddress, auditEvent.getUser().getIpAddress());
+        assertEquals(String.valueOf(sessionId), auditEvent.getUser().getSessionId());
+        assertEquals(persistentSessionId, auditEvent.getUser().getPersistentSessionId());
+        assertEquals(clientSessionId, auditEvent.getUser().getClientSessionId());
+
+        assertEquals(auditEventExtensions, auditEvent.getExtensions());
+
+        verify(mockClock, times(2)).instant();
+        verify(mockInstant).toEpochMilli();
+        verify(mockConfigurationService).getSqsAuditEventPrefix();
+        verify(mockConfigurationService).getVerifiableCredentialIssuer();
+    }
+
+    @Test
+    void shouldCreateAuditEventWithContextAndPersonIdentityRestricted() {
+        long timestamp = 1656947224L;
+        long eventTimestampMs = 165694722422L;
+        String userId = String.valueOf(UUID.randomUUID());
+        UUID sessionId = UUID.randomUUID();
+        String persistentSessionId = UUID.randomUUID().toString();
+        String clientSessionId = UUID.randomUUID().toString();
+        String clientIpAddress = "81.145.61.43";
+        when(mockConfigurationService.getSqsAuditEventPrefix()).thenReturn(TEST_AUDIT_EVENT_PREFIX);
+        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_VC_ISSUER);
+        Instant mockInstant = mock(Instant.class);
+        when(mockInstant.getEpochSecond()).thenReturn(timestamp);
+        when(mockInstant.toEpochMilli()).thenReturn(eventTimestampMs);
+        when(mockClock.instant()).thenReturn(mockInstant);
+
+        NamePart firstNamePart = new NamePart();
+        firstNamePart.setType("GivenName");
+        firstNamePart.setValue("Jon");
+        NamePart surnamePart = new NamePart();
+        surnamePart.setType("FamilyName");
+        surnamePart.setValue("Smith");
+        Name name = new Name();
+        name.setNameParts(List.of(firstNamePart, surnamePart));
+        List<Name> names = List.of(name);
+        BirthDate birthDate = new BirthDate();
+        birthDate.setValue(LocalDate.of(1984, 6, 27));
+        List<BirthDate> birthDates = List.of(birthDate);
+        @SuppressWarnings("deprecation")
+        PersonIdentityDetailed personIdentity = new PersonIdentityDetailed(names, birthDates);
         String encodedDeviceInformation = "123456789";
 
         Map<String, String> requestHeaders =


### PR DESCRIPTION
## Proposed changes

### What changed

Adds `device_information`  to restricted if the header is present

### Why did it change

To allow the inspection of user audit information and track possible fraud

### Screenshots

With header sent
<img width="732" alt="image" src="https://github.com/govuk-one-login/ipv-cri-lib/assets/40401118/7e5600cb-36e5-4353-9b02-ad2bc8b627df">

Without
<img width="727" alt="image" src="https://github.com/govuk-one-login/ipv-cri-lib/assets/40401118/5cc3cd8e-8231-410b-bf25-736cd50c835d">


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DCP-3351](https://govukverify.atlassian.net/browse/DCP-3351)
- [DCP-3352](https://govukverify.atlassian.net/browse/DCP-3352)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks

[DCP-3351]: https://govukverify.atlassian.net/browse/DCP-3351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DCP-3352]: https://govukverify.atlassian.net/browse/DCP-3352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ