### PR TITLE
OJ-2546: Update step definition to include txma header in session endpoint

### DIFF
--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/CommonApiClient.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/CommonApiClient.java
@@ -67,6 +67,27 @@ public class CommonApiClient {
         return sendHttpRequest(request);
     }
 
+    public HttpResponse<String> sendNewSessionRequest(String sessionRequestBody)
+            throws IOException, InterruptedException {
+        var request =
+                HttpRequest.newBuilder()
+                        .uri(
+                                new URIBuilder(
+                                                this.clientConfigurationService
+                                                        .getPrivateApiEndpoint())
+                                        .setPath(
+                                                this.clientConfigurationService.createUriPath(
+                                                        "session"))
+                                        .build())
+                        .header(HttpHeaders.ACCEPT, JSON_MIME_MEDIA_TYPE)
+                        .header(HttpHeaders.CONTENT_TYPE, JSON_MIME_MEDIA_TYPE)
+                        .header("X-Forwarded-For", "192.168.0.1")
+                        .header("Txma-Audit-Encoded", "deviceInformation")
+                        .POST(HttpRequest.BodyPublishers.ofString(sessionRequestBody))
+                        .build();
+        return sendHttpRequest(request);
+    }
+
     public HttpResponse<String> sendTokenRequest(String privateKeyJwt)
             throws IOException, InterruptedException {
         var request =

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CommonSteps.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CommonSteps.java
@@ -55,6 +55,16 @@ public class CommonSteps {
         this.testContext.setSessionId(deserializedResponse.get("session_id"));
     }
 
+    @When("user sends a POST request to session end point with txma header")
+    public void userSendsAPostRequestToSessionEndpointWithHeader() throws IOException, InterruptedException {
+
+        this.testContext.setResponse(this.commonApiClient.sendNewSessionRequest(sessionRequestBody));
+        Map<String, String> deserializedResponse =
+                objectMapper.readValue(
+                        this.testContext.getResponse().body(), new TypeReference<>() {});
+        this.testContext.setSessionId(deserializedResponse.get("session_id"));
+    }
+
     @When("user sends a GET request to authorization end point")
     public void userSendsAGetRequestToAuthorizationEndpoint()
             throws IOException, InterruptedException {

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CommonSteps.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CommonSteps.java
@@ -56,9 +56,11 @@ public class CommonSteps {
     }
 
     @When("user sends a POST request to session end point with txma header")
-    public void userSendsAPostRequestToSessionEndpointWithHeader() throws IOException, InterruptedException {
+    public void userSendsAPostRequestToSessionEndpointWithHeader()
+            throws IOException, InterruptedException {
 
-        this.testContext.setResponse(this.commonApiClient.sendNewSessionRequest(sessionRequestBody));
+        this.testContext.setResponse(
+                this.commonApiClient.sendNewSessionRequest(sessionRequestBody));
         Map<String, String> deserializedResponse =
                 objectMapper.readValue(
                         this.testContext.getResponse().body(), new TypeReference<>() {});


### PR DESCRIPTION

## Proposed changes

### What changed

Added new step definition for posting session request to include the `Txma-Audit-Encoded` header to be referenced in the address repo.

### Why did it change

To enable testing within the `Header` value within address-api repo 

### Issue tracking

- [OJ-2546](https://govukverify.atlassian.net/browse/OJ-2546)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2546]: https://govukverify.atlassian.net/browse/OJ-2546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ