### PR TITLE
OJ-2546: Update header for session endpoint

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.6.2
+
+* Created new step definition for posting session request to include new `txma-audit-encoded` header to be referenced in the address repository tests.
+
 ## 1.6.1
 
 * Update README

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.6.1"
+def buildVersion = "1.6.2"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/CommonApiClient.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/CommonApiClient.java
@@ -82,7 +82,7 @@ public class CommonApiClient {
                         .header(HttpHeaders.ACCEPT, JSON_MIME_MEDIA_TYPE)
                         .header(HttpHeaders.CONTENT_TYPE, JSON_MIME_MEDIA_TYPE)
                         .header("X-Forwarded-For", "192.168.0.1")
-                        .header("Txma-Audit-Encoded", "deviceInformation")
+                        .header("txma-audit-encoded", "deviceInformation")
                         .POST(HttpRequest.BodyPublishers.ofString(sessionRequestBody))
                         .build();
         return sendHttpRequest(request);


### PR DESCRIPTION
## Proposed changes

### What changed

Added new step definition for posting session request to include the `Txma-Audit-Encoded` header to be referenced in the address repo.

### Why did it change

To enable testing within the `Header` value within address-api repo 

### Issue tracking

- [OJ-2546](https://govukverify.atlassian.net/browse/OJ-2546)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [x] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2546]: https://govukverify.atlassian.net/browse/OJ-2546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ