### PR TITLE
LIME-1079 - Adding nino/personalNumber to sharedClaims and mapping to…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Credential Issuer common libraries Release Notes
 
+## 2.0.0
+
+* Added support for National Insurance number as SocialSecurityRecord
+* Bumped version to 2.0.0 following change to remove public constructor on ListUtil
+
 ## 1.7.0
 
 ### Added utilities for integration testing with AWS services

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.7.0"
+def buildVersion = "2.0.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/PersonIdentity.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/PersonIdentity.java
@@ -1,16 +1,21 @@
 package uk.gov.di.ipv.cri.common.library.domain.personidentity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PersonIdentity {
     private String firstName;
     private String middleNames;
     private String surname;
     private List<Address> addresses;
+    private List<SocialSecurityRecord> socialSecurityRecords;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate dateOfBirth;
@@ -57,5 +62,13 @@ public class PersonIdentity {
 
     public void setAddresses(List<Address> addresses) {
         this.addresses = addresses;
+    }
+
+    public List<SocialSecurityRecord> getSocialSecurityRecord() {
+        return socialSecurityRecords;
+    }
+
+    public void setSocialSecurityRecord(List<SocialSecurityRecord> socialSecurityRecord) {
+        this.socialSecurityRecords = socialSecurityRecord;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/PersonIdentityDetailed.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/PersonIdentityDetailed.java
@@ -10,6 +10,7 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PersonIdentityDetailed {
+
     @JsonProperty("name")
     private final List<Name> names;
 
@@ -25,6 +26,9 @@ public class PersonIdentityDetailed {
     @JsonProperty("passport")
     private final List<Passport> passports;
 
+    @JsonProperty("socialSecurityRecord")
+    private final List<SocialSecurityRecord> socialSecurityRecords;
+
     @JsonProperty("device_information")
     private DeviceInformation deviceInformation;
 
@@ -39,7 +43,7 @@ public class PersonIdentityDetailed {
      */
     @Deprecated(since = "1.5.0")
     public PersonIdentityDetailed(List<Name> names, List<BirthDate> birthDates) {
-        this(names, birthDates, null, null, null);
+        this(names, birthDates, null, null, null, null);
     }
 
     /**
@@ -53,7 +57,7 @@ public class PersonIdentityDetailed {
     @Deprecated(since = "1.5.0")
     public PersonIdentityDetailed(
             List<Name> names, List<BirthDate> birthDates, List<Address> addresses) {
-        this(names, birthDates, addresses, null, null);
+        this(names, birthDates, addresses, null, null, null);
     }
 
     /**
@@ -73,12 +77,18 @@ public class PersonIdentityDetailed {
             List<BirthDate> birthDates,
             List<Address> addresses,
             List<DrivingPermit> drivingPermits,
-            List<Passport> passports) {
+            List<Passport> passports,
+            List<SocialSecurityRecord> socialSecurityRecords) {
         this.names = names;
         this.birthDates = birthDates;
         this.addresses = addresses;
         this.drivingPermits = drivingPermits;
         this.passports = passports;
+        this.socialSecurityRecords = socialSecurityRecords;
+    }
+
+    public List<SocialSecurityRecord> getSocialSecurityRecords() {
+        return socialSecurityRecords;
     }
 
     public List<Name> getNames() {

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/SharedClaims.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/SharedClaims.java
@@ -1,10 +1,17 @@
 package uk.gov.di.ipv.cri.common.library.domain.personidentity;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SharedClaims {
+    @JsonProperty("socialSecurityRecord")
+    private List<SocialSecurityRecord> socialSecurityRecords;
+
     @JsonProperty("name")
     private List<Name> names;
 
@@ -47,5 +54,13 @@ public class SharedClaims {
 
     public void setAddresses(List<Address> addresses) {
         this.addresses = addresses;
+    }
+
+    public List<SocialSecurityRecord> getSocialSecurityRecords() {
+        return socialSecurityRecords;
+    }
+
+    public void setSocialSecurityRecords(List<SocialSecurityRecord> socialSecurityRecords) {
+        this.socialSecurityRecords = socialSecurityRecords;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/SocialSecurityRecord.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/SocialSecurityRecord.java
@@ -1,0 +1,22 @@
+package uk.gov.di.ipv.cri.common.library.domain.personidentity;
+
+import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentitySocialSecurityRecord;
+
+public class SocialSecurityRecord {
+
+    private String personalNumber;
+
+    public SocialSecurityRecord() {}
+
+    public SocialSecurityRecord(PersonIdentitySocialSecurityRecord socialSecurityRecord) {
+        this.personalNumber = socialSecurityRecord.getPersonalNumber();
+    }
+
+    public String getPersonalNumber() {
+        return personalNumber;
+    }
+
+    public void setPersonalNumber(String personalNumber) {
+        this.personalNumber = personalNumber;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/personidentity/PersonIdentityItem.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/personidentity/PersonIdentityItem.java
@@ -14,6 +14,7 @@ public class PersonIdentityItem {
     private List<PersonIdentityName> names;
     private List<PersonIdentityDateOfBirth> birthDates;
     private long expiryDate;
+    private List<PersonIdentitySocialSecurityRecord> socialSecurityRecords;
 
     @DynamoDbPartitionKey()
     public UUID getSessionId() {
@@ -54,5 +55,14 @@ public class PersonIdentityItem {
 
     public void setExpiryDate(long expiryDate) {
         this.expiryDate = expiryDate;
+    }
+
+    public List<PersonIdentitySocialSecurityRecord> getSocialSecurityRecords() {
+        return socialSecurityRecords;
+    }
+
+    public void setSocialSecurityRecords(
+            List<PersonIdentitySocialSecurityRecord> socialSecurityRecords) {
+        this.socialSecurityRecords = socialSecurityRecords;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/personidentity/PersonIdentitySocialSecurityRecord.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/personidentity/PersonIdentitySocialSecurityRecord.java
@@ -1,0 +1,16 @@
+package uk.gov.di.ipv.cri.common.library.persistence.item.personidentity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+
+@DynamoDbBean
+public class PersonIdentitySocialSecurityRecord {
+    private String personalNumber;
+
+    public String getPersonalNumber() {
+        return personalNumber;
+    }
+
+    public void setPersonalNumber(String personalNumber) {
+        this.personalNumber = personalNumber;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactory.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactory.java
@@ -63,7 +63,7 @@ public class AuditEventFactory {
 
         if (requestHeaders.containsKey(TXMA_AUDIT_ENCODED)) {
             if (Objects.isNull(restricted)) {
-                restricted = new PersonIdentityDetailed(null, null, null, null, null);
+                restricted = new PersonIdentityDetailed(null, null, null, null, null, null);
             }
             DeviceInformation deviceInformation = new DeviceInformation();
             deviceInformation.setEncoded(requestHeaders.get(TXMA_AUDIT_ENCODED));

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityDetailedBuilder.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityDetailedBuilder.java
@@ -6,6 +6,7 @@ import uk.gov.di.ipv.cri.common.library.domain.personidentity.DrivingPermit;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Name;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Passport;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.SocialSecurityRecord;
 
 import java.util.List;
 
@@ -30,6 +31,8 @@ public class PersonIdentityDetailedBuilder {
     }
 
     public static class Builder {
+
+        private List<SocialSecurityRecord> socialSecurityRecords;
         private List<Name> names;
         private List<BirthDate> birthDates;
         private List<Address> addresses;
@@ -60,10 +63,15 @@ public class PersonIdentityDetailedBuilder {
             return this;
         }
 
+        public Builder withNino(List<SocialSecurityRecord> socialSecurityRecords) {
+            this.socialSecurityRecords = socialSecurityRecords;
+            return this;
+        }
+
         @SuppressWarnings("deprecation")
         public PersonIdentityDetailed build() {
             return new PersonIdentityDetailed(
-                    names, birthDates, addresses, drivingPermits, passports);
+                    names, birthDates, addresses, drivingPermits, passports, socialSecurityRecords);
         }
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityDetailedFactory.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityDetailedFactory.java
@@ -23,7 +23,7 @@ public class PersonIdentityDetailedFactory {
     @SuppressWarnings("deprecation")
     public static PersonIdentityDetailed createPersonIdentityDetailedWithAddresses(
             List<Name> names, List<BirthDate> birthDates, List<Address> addresses) {
-        return new PersonIdentityDetailed(names, birthDates, addresses, null, null);
+        return new PersonIdentityDetailed(names, birthDates, addresses, null, null, null);
     }
 
     @SuppressWarnings("deprecation")
@@ -32,12 +32,12 @@ public class PersonIdentityDetailedFactory {
             List<BirthDate> birthDates,
             List<Address> addresses,
             List<DrivingPermit> drivingPermits) {
-        return new PersonIdentityDetailed(names, birthDates, addresses, drivingPermits, null);
+        return new PersonIdentityDetailed(names, birthDates, addresses, drivingPermits, null, null);
     }
 
     @SuppressWarnings("deprecation")
     public static PersonIdentityDetailed createPersonIdentityDetailedWithPassport(
             List<Name> names, List<BirthDate> birthDates, List<Passport> passports) {
-        return new PersonIdentityDetailed(names, birthDates, null, null, passports);
+        return new PersonIdentityDetailed(names, birthDates, null, null, passports, null);
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapper.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapper.java
@@ -7,11 +7,13 @@ import uk.gov.di.ipv.cri.common.library.domain.personidentity.NamePart;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.SharedClaims;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.SocialSecurityRecord;
 import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
 import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityDateOfBirth;
 import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityItem;
 import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityName;
 import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityNamePart;
+import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentitySocialSecurityRecord;
 
 import java.util.Collections;
 import java.util.List;
@@ -43,12 +45,15 @@ public class PersonIdentityMapper {
         if (notNullAndNotEmpty(sharedClaims.getAddresses())) {
             identity.setAddresses(mapAddresses(sharedClaims.getAddresses()));
         }
+        if (notNullAndNotEmpty(sharedClaims.getSocialSecurityRecords())) {
+            identity.setSocialSecurityRecords(
+                    mapSocialSecurityRecords(sharedClaims.getSocialSecurityRecords()));
+        }
         return identity;
     }
 
     PersonIdentity mapToPersonIdentity(PersonIdentityItem personIdentityItem) {
         PersonIdentity personIdentity = new PersonIdentity();
-
         if (notNullAndNotEmpty(personIdentityItem.getNames())) {
             PersonIdentityName personIdentityName = getCurrentName(personIdentityItem.getNames());
             mapName(personIdentityName, personIdentity);
@@ -60,6 +65,11 @@ public class PersonIdentityMapper {
 
         if (notNullAndNotEmpty(personIdentityItem.getAddresses())) {
             personIdentity.setAddresses(mapCanonicalAddresses(personIdentityItem.getAddresses()));
+        }
+
+        if (notNullAndNotEmpty(personIdentityItem.getSocialSecurityRecords())) {
+            personIdentity.setSocialSecurityRecord(
+                    mapSocialSecurityRecord(personIdentityItem.getSocialSecurityRecords()));
         }
 
         return personIdentity;
@@ -77,9 +87,14 @@ public class PersonIdentityMapper {
         if (notNullAndNotEmpty(personIdentityDetailed.getAddresses())) {
             personIdentity.setAddresses(personIdentityDetailed.getAddresses());
         }
+        if (notNullAndNotEmpty(personIdentityDetailed.getSocialSecurityRecords())) {
+            personIdentity.setSocialSecurityRecord(
+                    personIdentityDetailed.getSocialSecurityRecords());
+        }
         return personIdentity;
     }
 
+    @SuppressWarnings({"java:S1481", "java:S1854"})
     PersonIdentityDetailed mapToPersonIdentityDetailed(PersonIdentityItem personIdentityItem) {
         List<Name> names = Collections.emptyList();
         if (notNullAndNotEmpty(personIdentityItem.getNames())) {
@@ -96,12 +111,26 @@ public class PersonIdentityMapper {
             addresses = mapCanonicalAddresses(personIdentityItem.getAddresses());
         }
 
+        List<SocialSecurityRecord> socialSecurityRecords = Collections.emptyList();
+        if (notNullAndNotEmpty(personIdentityItem.getSocialSecurityRecords())) {
+            socialSecurityRecords =
+                    mapPersonIdentitySocialSecurityRecords(
+                            personIdentityItem.getSocialSecurityRecords());
+        }
+
         return PersonIdentityDetailedFactory.createPersonIdentityDetailedWithAddresses(
                 names, dobs, addresses);
     }
 
     private List<Address> mapCanonicalAddresses(List<CanonicalAddress> addresses) {
         return addresses.stream().map(Address::new).collect(Collectors.toList());
+    }
+
+    private List<SocialSecurityRecord> mapSocialSecurityRecord(
+            List<PersonIdentitySocialSecurityRecord> socialSecurityRecords) {
+        return socialSecurityRecords.stream()
+                .map(SocialSecurityRecord::new)
+                .collect(Collectors.toList());
     }
 
     private List<BirthDate> mapPersonIdentityBirthDates(
@@ -134,6 +163,19 @@ public class PersonIdentityMapper {
                                             .collect(Collectors.toList());
                             mappedName.setNameParts(mappedNameParts);
                             return mappedName;
+                        })
+                .collect(Collectors.toList());
+    }
+
+    private List<SocialSecurityRecord> mapPersonIdentitySocialSecurityRecords(
+            List<PersonIdentitySocialSecurityRecord> socialSecurityRecords) {
+        return socialSecurityRecords.stream()
+                .map(
+                        securityRecord -> {
+                            SocialSecurityRecord mappedSocialRecord = new SocialSecurityRecord();
+                            mappedSocialRecord.setPersonalNumber(
+                                    securityRecord.getPersonalNumber());
+                            return mappedSocialRecord;
                         })
                 .collect(Collectors.toList());
     }
@@ -271,6 +313,19 @@ public class PersonIdentityMapper {
                                     a.getDoubleDependentAddressLocality());
 
                             return canonicalAddress;
+                        })
+                .collect(Collectors.toList());
+    }
+
+    private List<PersonIdentitySocialSecurityRecord> mapSocialSecurityRecords(
+            List<SocialSecurityRecord> socialSecurityRecords) {
+        return socialSecurityRecords.stream()
+                .map(
+                        sr -> {
+                            PersonIdentitySocialSecurityRecord personalNumber =
+                                    new PersonIdentitySocialSecurityRecord();
+                            personalNumber.setPersonalNumber(sr.getPersonalNumber());
+                            return personalNumber;
                         })
                 .collect(Collectors.toList());
     }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityDetailedBuilderTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityDetailedBuilderTest.java
@@ -10,6 +10,7 @@ import uk.gov.di.ipv.cri.common.library.domain.personidentity.Name;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.NamePart;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Passport;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.SocialSecurityRecord;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -22,6 +23,7 @@ class PersonIdentityDetailedBuilderTest {
     class BuilderWithNamesParts {
         @Test
         void shouldUseBuilderToCreatePersonIdentityDetailedWithDrivingPermit() {
+
             NamePart firstNamePart = new NamePart();
             firstNamePart.setType("GivenName");
             firstNamePart.setValue("Jon");
@@ -82,10 +84,12 @@ class PersonIdentityDetailedBuilderTest {
             assertEquals(drivingPermit.getIssueNumber(), pidDrivingPermit.getIssueNumber());
 
             assertNull(personIdentityDetailed.getPassports());
+            assertNull(personIdentityDetailed.getSocialSecurityRecords());
         }
 
         @Test
         void shouldUseBuilderToCreatePersonIdentityWithPassport() {
+
             NamePart firstNamePart = new NamePart();
             firstNamePart.setType("GivenName");
             firstNamePart.setValue("Jon");
@@ -129,6 +133,55 @@ class PersonIdentityDetailedBuilderTest {
             assertEquals(passport.getDocumentNumber(), pidPassport.getDocumentNumber());
             assertEquals(passport.getExpiryDate(), pidPassport.getExpiryDate());
             assertEquals(passport.getIcaoIssuerCode(), pidPassport.getIcaoIssuerCode());
+
+            assertNull(personIdentityDetailed.getAddresses());
+            assertNull(personIdentityDetailed.getDrivingPermits());
+            assertNull(personIdentityDetailed.getSocialSecurityRecords());
+        }
+
+        @Test
+        void shouldUseBuilderToCreatePersonIdentityWithNino() {
+            SocialSecurityRecord socialSecurityRecord = new SocialSecurityRecord();
+            socialSecurityRecord.setPersonalNumber("AA000003D");
+            List<SocialSecurityRecord> socialSecurityRecords = List.of(socialSecurityRecord);
+
+            NamePart firstNamePart = new NamePart();
+            firstNamePart.setType("GivenName");
+            firstNamePart.setValue("Jon");
+            NamePart surnamePart = new NamePart();
+            surnamePart.setType("FamilyName");
+            surnamePart.setValue("Smith");
+            Name name = new Name();
+            name.setNameParts(List.of(firstNamePart, surnamePart));
+            List<Name> names = List.of(name);
+
+            LocalDate dob = LocalDate.of(1984, 6, 27);
+            BirthDate birthDate = new BirthDate();
+            birthDate.setValue(dob);
+            List<BirthDate> birthDates = List.of(birthDate);
+
+            PersonIdentityDetailed personIdentityDetailed =
+                    PersonIdentityDetailedBuilder.builder(names, birthDates)
+                            .withNino(socialSecurityRecords)
+                            .build();
+
+            assertEquals(names, personIdentityDetailed.getNames());
+            assertEquals(
+                    firstNamePart.getValue(),
+                    personIdentityDetailed.getNames().get(0).getNameParts().get(0).getValue());
+            assertEquals(
+                    surnamePart.getValue(),
+                    personIdentityDetailed.getNames().get(0).getNameParts().get(1).getValue());
+
+            assertEquals(birthDates, personIdentityDetailed.getBirthDates());
+            assertEquals(
+                    birthDate.getValue(), personIdentityDetailed.getBirthDates().get(0).getValue());
+
+            SocialSecurityRecord personSocialSecurityRecord =
+                    personIdentityDetailed.getSocialSecurityRecords().get(0);
+            assertEquals(
+                    personSocialSecurityRecord.getPersonalNumber(),
+                    socialSecurityRecords.get(0).getPersonalNumber());
 
             assertNull(personIdentityDetailed.getAddresses());
             assertNull(personIdentityDetailed.getDrivingPermits());

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapperTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapperTest.java
@@ -12,11 +12,13 @@ import uk.gov.di.ipv.cri.common.library.domain.personidentity.NamePart;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.SharedClaims;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.SocialSecurityRecord;
 import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
 import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityDateOfBirth;
 import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityItem;
 import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityName;
 import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityNamePart;
+import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentitySocialSecurityRecord;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -58,10 +60,15 @@ class PersonIdentityMapperTest {
         address.setPostalCode("postcode");
         address.setValidFrom(TODAY);
 
+        PersonIdentitySocialSecurityRecord socialSecurityRecord =
+                new PersonIdentitySocialSecurityRecord();
+        socialSecurityRecord.setPersonalNumber("AA000003D");
+
         PersonIdentityItem testPersonIdentityItem = new PersonIdentityItem();
         testPersonIdentityItem.setNames(List.of(name));
         testPersonIdentityItem.setBirthDates(List.of(birthDate));
         testPersonIdentityItem.setAddresses(List.of(address));
+        testPersonIdentityItem.setSocialSecurityRecords(List.of(socialSecurityRecord));
 
         PersonIdentity mappedPersonIdentity =
                 this.personIdentityMapper.mapToPersonIdentity(testPersonIdentityItem);
@@ -77,6 +84,9 @@ class PersonIdentityMapperTest {
         assertEquals(address.getPostalCode(), mappedAddress.getPostalCode());
         assertEquals(address.getValidFrom(), mappedAddress.getValidFrom());
         assertEquals(AddressType.CURRENT, mappedAddress.getAddressType());
+        assertEquals(
+                socialSecurityRecord.getPersonalNumber(),
+                testPersonIdentityItem.getSocialSecurityRecords().get(0).getPersonalNumber());
     }
 
     @Test
@@ -194,11 +204,18 @@ class PersonIdentityMapperTest {
         address.setValidFrom(TODAY);
         sharedClaims.setAddresses(List.of(address));
 
+        SocialSecurityRecord socialSecurityRecord = new SocialSecurityRecord();
+        socialSecurityRecord.setPersonalNumber("AA000003D");
+        sharedClaims.setSocialSecurityRecords(List.of(socialSecurityRecord));
+
         PersonIdentityItem mappedPersonIdentityItem =
                 personIdentityMapper.mapToPersonIdentityItem(sharedClaims);
 
         PersonIdentityName mappedName = mappedPersonIdentityItem.getNames().get(0);
         CanonicalAddress mappedAddress = mappedPersonIdentityItem.getAddresses().get(0);
+        PersonIdentitySocialSecurityRecord mappedSocialSecurityRecord =
+                mappedPersonIdentityItem.getSocialSecurityRecords().get(0);
+
         assertEquals(firstNamePart.getValue(), mappedName.getNameParts().get(0).getValue());
         assertEquals(firstNamePart.getType(), mappedName.getNameParts().get(0).getType());
         assertEquals(surnamePart.getValue(), mappedName.getNameParts().get(1).getValue());
@@ -212,6 +229,9 @@ class PersonIdentityMapperTest {
         assertEquals(address.getPostalCode(), mappedAddress.getPostalCode());
         assertEquals(TODAY, mappedAddress.getValidFrom());
         assertNull(mappedAddress.getValidUntil());
+        assertEquals(
+                socialSecurityRecord.getPersonalNumber(),
+                mappedSocialSecurityRecord.getPersonalNumber());
     }
 
     @Test
@@ -245,10 +265,16 @@ class PersonIdentityMapperTest {
         address.setValidFrom(LocalDate.of(2011, 10, 21));
         address.setValidUntil(LocalDate.of(2017, 11, 25));
 
+        PersonIdentitySocialSecurityRecord personIdentitySocialSecurityRecord =
+                new PersonIdentitySocialSecurityRecord();
+        personIdentitySocialSecurityRecord.setPersonalNumber("AA000003D");
+
         PersonIdentityItem testPersonIdentityItem = new PersonIdentityItem();
         testPersonIdentityItem.setNames(List.of(name));
         testPersonIdentityItem.setBirthDates(List.of(birthDate));
         testPersonIdentityItem.setAddresses(List.of(address));
+        testPersonIdentityItem.setSocialSecurityRecords(
+                List.of(personIdentitySocialSecurityRecord));
 
         PersonIdentityDetailed mappedPersonIdentity =
                 personIdentityMapper.mapToPersonIdentityDetailed(testPersonIdentityItem);
@@ -277,6 +303,11 @@ class PersonIdentityMapperTest {
         assertEquals(address.getStreetName(), mappedAddress.getStreetName());
         assertEquals(address.getSubBuildingName(), mappedAddress.getSubBuildingName());
         assertEquals(address.getUprn(), mappedAddress.getUprn());
+
+        // CRIs using a java backend currently shouldn't have a nino sent to them,
+        // functionality has been added in case this changes in the future but for now
+        // this checks the value hasn't been mapped into the personIdentity
+        assertNull(mappedPersonIdentity.getSocialSecurityRecords());
     }
 
     @Test


### PR DESCRIPTION
### What changed
 - Added nino to sharedClaims under field "personalNumber"
 - Added models for socialSecurityNumber (which is the object that will house personalNumber/Nino) so both sharedClaims and personIdentity
 - Updated sharedClaim -> personIdentity mappers to reflect new field
 - Updated tests to include new field
 
 This change has been made as part of the HMRC KBV initiative so that a users national insurance number (nino) can be saved to a personsIdentity in dynamo, this PR must go in before the relating common-lambdas PR - https://github.com/govuk-one-login/ipv-cri-common-lambdas/pull/295
 
 