### PR TITLE
OJ-2546: Add list utils to allow for adding and removing unique elements using custom comparators

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
@@ -22,7 +22,6 @@ public class SessionService {
     private static final String GOVUK_SIGNIN_JOURNEY_ID = "govuk_signin_journey_id";
     private final ConfigurationService configurationService;
     private final DataStore<SessionItem> dataStore;
-    private final ListUtil listUtil;
     private final Clock clock;
 
     @ExcludeFromGeneratedCoverageReport
@@ -34,7 +33,6 @@ public class SessionService {
                         SessionItem.class,
                         new DynamoDbEnhancedClientFactory().getClient());
         this.clock = Clock.systemUTC();
-        this.listUtil = new ListUtil();
     }
 
     @ExcludeFromGeneratedCoverageReport
@@ -45,19 +43,16 @@ public class SessionService {
                         SessionItem.class,
                         new DynamoDbEnhancedClientFactory().getClient()),
                 configurationService,
-                Clock.systemUTC(),
-                new ListUtil());
+                Clock.systemUTC());
     }
 
     public SessionService(
             DataStore<SessionItem> dataStore,
             ConfigurationService configurationService,
-            Clock clock,
-            ListUtil listUtil) {
+            Clock clock) {
         this.dataStore = dataStore;
         this.configurationService = configurationService;
         this.clock = clock;
-        this.listUtil = listUtil;
     }
 
     public UUID saveSession(SessionRequest sessionRequest) {
@@ -129,7 +124,7 @@ public class SessionService {
 
         try {
             sessionItem =
-                    listUtil.getOneItemOrThrowError(
+                    ListUtil.getOneItemOrThrowError(
                             dataStore.getItemByIndex(
                                     SessionItem.ACCESS_TOKEN_INDEX,
                                     accessToken.toAuthorizationHeader()));
@@ -158,7 +153,7 @@ public class SessionService {
 
         try {
             sessionItem =
-                    listUtil.getOneItemOrThrowError(
+                    ListUtil.getOneItemOrThrowError(
                             dataStore.getItemByIndex(
                                     SessionItem.AUTHORIZATION_CODE_INDEX, authCode));
         } catch (IllegalArgumentException e) {

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/ListUtil.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/ListUtil.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.cri.common.library.util;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -14,5 +15,28 @@ public final class ListUtil {
         } else {
             return list.get(0);
         }
+    }
+
+    /**
+     * Split a list into batches of specified size.
+     *
+     * @param list The list to split into batches
+     * @param batchSize The size of each batch. The last sublist will have between 1 and {@code
+     *     batchSize} items
+     * @return A list of items split into batches
+     * @throws IllegalArgumentException If the list is null or the batch size is less than 1
+     */
+    public static <T> List<List<T>> split(List<T> list, int batchSize) {
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("Batch size must be greater than 0");
+        }
+
+        List<List<T>> batches = new ArrayList<>();
+
+        for (int idx = 0; idx < list.size(); idx += batchSize) {
+            batches.add(list.subList(idx, Math.min(list.size(), idx + batchSize)));
+        }
+
+        return batches;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/ListUtil.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/ListUtil.java
@@ -68,6 +68,29 @@ public final class ListUtil {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Modify the {@code source} list to remove the elements contained in the {@code except} list
+     * using when compared using a custom {@code mapper} function.
+     *
+     * @param source The source list to filter
+     * @param except The list containing the elements to exclude
+     * @param mapper A function mapping list elements to values used to determine element equality
+     */
+    public static <T, U extends Comparable<? super U>> void exclude(
+            List<T> source, List<T> except, Function<? super T, ? extends U> mapper) {
+        exclude(source, except, Comparator.comparing(mapper));
+    }
+
+    /**
+     * Modify the {@code source} list to remove the elements contained in the {@code except} list
+     * using when compared using a custom {@link Comparator comparator} function.
+     *
+     * @see ListUtil#exclude(List, List, Function)
+     */
+    public static <T> void exclude(List<T> source, List<T> except, Comparator<T> comparator) {
+        source.removeIf(element -> contains(except, element, comparator));
+    }
+
     private static <T> boolean contains(List<T> list, T exclude, Comparator<T> comparator) {
         return list.stream().anyMatch(element -> objectsEqual(element, exclude, comparator));
     }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/ListUtil.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/ListUtil.java
@@ -1,8 +1,11 @@
 package uk.gov.di.ipv.cri.common.library.util;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public final class ListUtil {
     private ListUtil() {}
@@ -38,5 +41,38 @@ public final class ListUtil {
         }
 
         return batches;
+    }
+
+    /**
+     * Create a new list comprised of elements in the {@code source} list except those in the {@code
+     * except} when compared using a custom {@code mapper} function.
+     *
+     * @param source The source list to filter
+     * @param except The list containing the elements to exclude
+     * @param mapper A function mapping list elements to values used to determine element equality
+     */
+    public static <T, U extends Comparable<? super U>> List<T> except(
+            List<T> source, List<T> except, Function<? super T, ? extends U> mapper) {
+        return except(source, except, Comparator.comparing(mapper));
+    }
+
+    /**
+     * Create a new list comprised of elements in the {@code source} list except those in the {@code
+     * except} when compared using a custom {@link Comparator comparator} function.
+     *
+     * @see ListUtil#except(List, List, Function)
+     */
+    public static <T> List<T> except(List<T> source, List<T> except, Comparator<T> comparator) {
+        return source.stream()
+                .filter(element -> !contains(except, element, comparator))
+                .collect(Collectors.toList());
+    }
+
+    private static <T> boolean contains(List<T> list, T exclude, Comparator<T> comparator) {
+        return list.stream().anyMatch(element -> objectsEqual(element, exclude, comparator));
+    }
+
+    private static <T> boolean objectsEqual(T a, T b, Comparator<T> comparator) {
+        return comparator.compare(a, b) == 0;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/ListUtil.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/ListUtil.java
@@ -3,8 +3,10 @@ package uk.gov.di.ipv.cri.common.library.util;
 import java.util.List;
 import java.util.Objects;
 
-public class ListUtil {
-    public <T> T getOneItemOrThrowError(List<T> list) throws IllegalArgumentException {
+public final class ListUtil {
+    private ListUtil() {}
+
+    public static <T> T getOneItemOrThrowError(List<T> list) throws IllegalArgumentException {
         if (Objects.isNull(list) || list.isEmpty()) {
             throw new IllegalArgumentException("No items found");
         } else if (list.size() > 1) {

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/ListUtil.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/ListUtil.java
@@ -91,8 +91,35 @@ public final class ListUtil {
         source.removeIf(element -> contains(except, element, comparator));
     }
 
-    private static <T> boolean contains(List<T> list, T exclude, Comparator<T> comparator) {
-        return list.stream().anyMatch(element -> objectsEqual(element, exclude, comparator));
+    /**
+     * Merge two lists without duplicating any elements. Elements from the {@code source} list are
+     * replaced by elements from the {@code merge} list if they are equal when evaluated using the
+     * {@code mapper} function.
+     *
+     * @param source The source list to be modified with the new elements
+     * @param merge The list with the elements to be added to the source list
+     * @param mapper A function mapping list elements to values used to determine element equality
+     */
+    public static <T, U extends Comparable<? super U>> void mergeDistinct(
+            List<T> source, List<T> merge, Function<? super T, ? extends U> mapper) {
+        mergeDistinct(source, merge, Comparator.comparing(mapper));
+    }
+
+    /**
+     * Merge two lists without duplicating any elements. Elements from the {@code source} list are
+     * replaced by elements from the {@code merge} list if they are equal when evaluated using the
+     * {@code comparator} function.
+     *
+     * @param comparator A {@link Comparator comparator} function used to determine element equality
+     * @see ListUtil#mergeDistinct(List, List, Function)
+     */
+    public static <T> void mergeDistinct(List<T> source, List<T> merge, Comparator<T> comparator) {
+        exclude(source, merge, comparator);
+        source.addAll(merge);
+    }
+
+    private static <T> boolean contains(List<T> list, T object, Comparator<T> comparator) {
+        return list.stream().anyMatch(element -> objectsEqual(element, object, comparator));
     }
 
     private static <T> boolean objectsEqual(T a, T b, Comparator<T> comparator) {

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/ListUtil.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/ListUtil.java
@@ -118,7 +118,18 @@ public final class ListUtil {
         source.addAll(merge);
     }
 
-    private static <T> boolean contains(List<T> list, T object, Comparator<T> comparator) {
+    /**
+     * Determine whether a list contains an element using a custom comparator. This allows to select
+     * only certain fields or specify a custom function to determine equality between objects.
+     *
+     * @param list The source list to test for existence of the object
+     * @param object Determine whether this object is an element of the list given the {@code
+     *     comparator}
+     * @param comparator The {@link Comparator comparator} function used to determine object
+     *     equality
+     * @return {@code true} if the object is determined to be contained in the {@code list}
+     */
+    public static <T> boolean contains(List<T> list, T object, Comparator<T> comparator) {
         return list.stream().anyMatch(element -> objectsEqual(element, object, comparator));
     }
 

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
@@ -20,7 +20,6 @@ import uk.gov.di.ipv.cri.common.library.exception.SessionExpiredException;
 import uk.gov.di.ipv.cri.common.library.exception.SessionNotFoundException;
 import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
-import uk.gov.di.ipv.cri.common.library.util.ListUtil;
 
 import java.net.URI;
 import java.time.Clock;
@@ -47,7 +46,6 @@ class SessionServiceTest {
 
     @Mock private DataStore<SessionItem> mockDataStore;
     @Mock private ConfigurationService mockConfigurationService;
-    @Mock private ListUtil mockListUtil;
     @Captor private ArgumentCaptor<SessionItem> sessionItemArgumentCaptor;
 
     @BeforeAll
@@ -58,8 +56,7 @@ class SessionServiceTest {
     @BeforeEach
     void setUp() {
         Clock nowClock = Clock.fixed(fixedInstant, ZoneId.systemDefault());
-        sessionService =
-                new SessionService(mockDataStore, mockConfigurationService, nowClock, mockListUtil);
+        sessionService = new SessionService(mockDataStore, mockConfigurationService, nowClock);
     }
 
     @Test
@@ -114,7 +111,6 @@ class SessionServiceTest {
         setClientSessionIds(item);
         List<SessionItem> items = List.of(item);
 
-        when(mockListUtil.getOneItemOrThrowError(items)).thenReturn(item);
         when(mockDataStore.getItemByIndex(SessionItem.AUTHORIZATION_CODE_INDEX, authCodeValue))
                 .thenReturn(items);
         when(mockDataStore.getItem(item.getSessionId().toString())).thenReturn(item);
@@ -141,7 +137,6 @@ class SessionServiceTest {
         setClientSessionIds(item);
         List<SessionItem> items = List.of(item);
 
-        when(mockListUtil.getOneItemOrThrowError(items)).thenReturn(item);
         when(mockDataStore.getItemByIndex(SessionItem.ACCESS_TOKEN_INDEX, serialisedAccessToken))
                 .thenReturn(items);
         when(mockDataStore.getItem(item.getSessionId().toString())).thenReturn(item);
@@ -183,7 +178,6 @@ class SessionServiceTest {
                 Instant.now().minus(1, ChronoUnit.DAYS).getEpochSecond());
         List<SessionItem> items = List.of(item);
 
-        when(mockListUtil.getOneItemOrThrowError(items)).thenReturn(item);
         when(mockDataStore.getItemByIndex(SessionItem.AUTHORIZATION_CODE_INDEX, authorizationCode))
                 .thenReturn(items);
         when(mockDataStore.getItem(item.getSessionId().toString())).thenReturn(item);
@@ -204,7 +198,6 @@ class SessionServiceTest {
         item.setAccessTokenExpiryDate(Instant.now().minus(1, ChronoUnit.DAYS).getEpochSecond());
         List<SessionItem> items = List.of(item);
 
-        when(mockListUtil.getOneItemOrThrowError(items)).thenReturn(item);
         when(mockDataStore.getItemByIndex(SessionItem.ACCESS_TOKEN_INDEX, serialisedAccessToken))
                 .thenReturn(items);
         when(mockDataStore.getItem(item.getSessionId().toString())).thenReturn(item);

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/ListUtilTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/ListUtilTest.java
@@ -4,8 +4,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -33,5 +33,67 @@ class ListUtilTest {
     @Test
     void getOneItemOrThrowError_shouldReturnElementFromSingletonList() {
         assertEquals(1, ListUtil.getOneItemOrThrowError(Collections.singletonList(1)));
+    }
+
+    @Test
+    void split_shouldThrowIfListIsNull() {
+        assertThrows(NullPointerException.class, () -> ListUtil.split(null, 1));
+    }
+
+    @Test
+    void split_shouldThrowIfBatchSizeIsNegative() {
+        final List<Object> list = Collections.emptyList();
+
+        assertThrows(IllegalArgumentException.class, () -> ListUtil.split(list, -1));
+    }
+
+    @Test
+    void split_shouldThrowIfBatchSizeIsZero() {
+        final List<Object> list = Collections.emptyList();
+
+        assertThrows(IllegalArgumentException.class, () -> ListUtil.split(list, 0));
+    }
+
+    @Test
+    void split_shouldHandleSingletonList() {
+        final List<Integer> list = Collections.singletonList(1);
+
+        final List<List<Integer>> batches = ListUtil.split(list, 10);
+
+        assertEquals(1, batches.size());
+        assertEquals(list, batches.get(0));
+    }
+
+    @Test
+    void split_shouldReturnSingleListIfBatchSizeIsGreaterThanListSize() {
+        final List<Integer> list = List.of(1, 2, 3);
+
+        final List<List<Integer>> batches = ListUtil.split(list, 10);
+
+        assertEquals(1, batches.size());
+        assertEquals(list, batches.get(0));
+    }
+
+    @Test
+    void split_shouldSplitListIntoBatchesOfEqualSize() {
+        final List<Integer> list = List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+
+        final List<List<Integer>> batches = ListUtil.split(list, 4);
+
+        assertEquals(3, batches.size());
+        assertEquals(List.of(1, 2, 3, 4), batches.get(0));
+        assertEquals(List.of(5, 6, 7, 8), batches.get(1));
+        assertEquals(List.of(9, 10, 11, 12), batches.get(2));
+    }
+
+    @Test
+    void split_shouldPutRemainingElementsIntoTheLastBatch() {
+        final List<Integer> list = List.of(1, 2, 3, 4, 5);
+
+        final List<List<Integer>> batches = ListUtil.split(list, 3);
+
+        assertEquals(2, batches.size());
+        assertEquals(List.of(1, 2, 3), batches.get(0));
+        assertEquals(List.of(4, 5), batches.get(1));
     }
 }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/ListUtilTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/ListUtilTest.java
@@ -14,7 +14,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 class ListUtilTest {
@@ -483,5 +485,54 @@ class ListUtilTest {
 
         ListUtil.mergeDistinct(list, Collections.singletonList(new Point(1, 4)), Point::getY);
         assertEquals(List.of(new Point(2, 6), new Point(1, 5), new Point(1, 4)), list);
+    }
+
+    // *** #contains ***//
+
+    @Test
+    void contains_shouldThrowIfSourceListIsNull() {
+        final Comparator<Integer> comparator = Comparator.naturalOrder();
+        assertThrows(NullPointerException.class, () -> ListUtil.contains(null, 1, comparator));
+    }
+
+    @Test
+    void contains_shouldThrowIfObjectIsNull() {
+        final List<Integer> list = Collections.singletonList(1);
+        final Comparator<Integer> comparator = Comparator.naturalOrder();
+
+        assertThrows(NullPointerException.class, () -> ListUtil.contains(list, null, comparator));
+    }
+
+    @Test
+    void contains_shouldReturnFalseIfSourceListIsEmpty() {
+        assertFalse(ListUtil.contains(Collections.emptyList(), 1, Comparator.naturalOrder()));
+    }
+
+    @Test
+    void contains_shouldReturnFalseIfListDoesNotContainPrimitiveObject() {
+        assertFalse(ListUtil.contains(Collections.singletonList(1), 2, Comparator.naturalOrder()));
+    }
+
+    @Test
+    void contains_shouldReturnTrueIfListContainsPrimitiveObject() {
+        assertTrue(ListUtil.contains(List.of(1, 2, 3), 2, Comparator.naturalOrder()));
+    }
+
+    @Test
+    void contains_shouldReturnTrueIfListContainsComplexObject() {
+        assertTrue(
+                ListUtil.contains(
+                        List.of(new Point(1, 2), new Point(3, 4)),
+                        new Point(1, 5),
+                        Comparator.comparing(Point::getX)));
+    }
+
+    @Test
+    void contains_shouldReturnFalseIfListDoesNotContainComplexObject() {
+        assertFalse(
+                ListUtil.contains(
+                        List.of(new Point(1, 2), new Point(3, 4)),
+                        new Point(1, 5),
+                        Comparator.comparing(Point::getY)));
     }
 }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/ListUtilTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/ListUtilTest.java
@@ -1,0 +1,37 @@
+package uk.gov.di.ipv.cri.common.library.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class ListUtilTest {
+
+    @Test
+    void getOneItemOrThrowError_shouldThrowIfListIsNull() {
+        assertThrows(IllegalArgumentException.class, () -> ListUtil.getOneItemOrThrowError(null));
+    }
+
+    @Test
+    void getOneItemOrThrowError_shouldThrowIfListIsEmpty() {
+        final List<Object> list = Collections.emptyList();
+        assertThrows(IllegalArgumentException.class, () -> ListUtil.getOneItemOrThrowError(list));
+    }
+
+    @Test
+    void getOneItemOrThrowError_shouldThrowIfListHasMoreThanOneElement() {
+        final List<Integer> list = List.of(1, 2, 3);
+        assertThrows(IllegalArgumentException.class, () -> ListUtil.getOneItemOrThrowError(list));
+    }
+
+    @Test
+    void getOneItemOrThrowError_shouldReturnElementFromSingletonList() {
+        assertEquals(1, ListUtil.getOneItemOrThrowError(Collections.singletonList(1)));
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/ListUtilTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/ListUtilTest.java
@@ -4,8 +4,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.awt.Point;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -95,5 +99,129 @@ class ListUtilTest {
         assertEquals(2, batches.size());
         assertEquals(List.of(1, 2, 3), batches.get(0));
         assertEquals(List.of(4, 5), batches.get(1));
+    }
+
+    @Test
+    void except_shouldThrowIfSourceListIsNull() {
+        final List<Object> except = Collections.emptyList();
+
+        assertThrows(
+                NullPointerException.class, () -> ListUtil.except(null, except, Object::toString));
+    }
+
+    @Test
+    void except_shouldThrowIfExcludeListIsNull() {
+        final List<Integer> source = Collections.singletonList(1);
+
+        assertThrows(
+                NullPointerException.class, () -> ListUtil.except(source, null, Object::toString));
+    }
+
+    @Test
+    void except_shouldReturnEmptyListIfSourceListIsEmpty() {
+        assertEquals(
+                Collections.emptyList(),
+                ListUtil.except(
+                        Collections.emptyList(), Collections.emptyList(), Object::toString));
+
+        assertEquals(
+                Collections.emptyList(),
+                ListUtil.except(Collections.emptyList(), List.of(1, 2, 3), Object::toString));
+    }
+
+    @Test
+    void except_shouldReturnEmptyListIfSourceListMatchesExcludeList() {
+        final List<Integer> list = List.of(1, 2, 3);
+        assertEquals(
+                Collections.emptyList(),
+                ListUtil.except(list, List.copyOf(list), Object::toString));
+    }
+
+    @Test
+    void except_shouldReturnSourceListIfExcludeListIsEmpty() {
+        final List<Integer> list = List.of(1, 2, 3);
+        assertEquals(list, ListUtil.except(list, Collections.emptyList(), Object::toString));
+    }
+
+    @Test
+    void except_shouldReturnSourceListIfExcludeListDoesNotHaveCommonElements() {
+        final List<Integer> list = List.of(1, 2, 3);
+        assertEquals(list, ListUtil.except(list, List.of(4, 5, 6), Object::toString));
+    }
+
+    @Test
+    void except_shouldExcludeAllElementsFromExcludeList() {
+        final List<Integer> list = List.of(1, 2, 3, 4, 5, 6);
+        assertEquals(List.of(1, 3, 6), ListUtil.except(list, List.of(2, 4, 5), Object::toString));
+    }
+
+    @Test
+    void except_shouldExcludeAllElementsContainedInExcludeList() {
+        final List<Integer> list = List.of(1, 2, 3, 4, 5, 6);
+        assertEquals(
+                List.of(2, 4, 5, 6), ListUtil.except(list, List.of(1, 3, 7, 8), Object::toString));
+    }
+
+    @Test
+    void except_shouldExcludeComplexTypes() {
+        final List<Point> points = List.of(new Point(1, 2), new Point(3, 4));
+
+        assertEquals(
+                List.of(new Point(1, 2)),
+                ListUtil.except(
+                        points, Collections.singletonList(points.get(1)), Object::toString));
+    }
+
+    @Test
+    void except_shouldExcludeCollections() {
+        final List<Collection<Integer>> lists = List.of(List.of(1, 2, 3), List.of(4, 5, 6));
+
+        assertEquals(
+                List.of(List.of(1, 2, 3)),
+                ListUtil.except(lists, Collections.singletonList(lists.get(1)), Object::toString));
+    }
+
+    @Test
+    void except_shouldExcludeMaps() {
+        final List<Map<String, Integer>> maps = List.of(Map.of("one", 1), Map.of("two", 2));
+
+        assertEquals(
+                List.of(Map.of("one", 1)),
+                ListUtil.except(maps, Collections.singletonList(maps.get(1)), Object::toString));
+    }
+
+    @Test
+    void except_shouldExcludeUsingCustomComparator() {
+        final List<Point> points = List.of(new Point(1, 2), new Point(3, 4));
+        final List<Point> exclude = Collections.singletonList(new Point(1, 4));
+
+        assertEquals(
+                List.of(new Point(3, 4)),
+                ListUtil.except(points, exclude, Comparator.comparing(Point::getX)));
+
+        assertEquals(
+                List.of(new Point(1, 2)),
+                ListUtil.except(points, exclude, Comparator.comparing(Point::getY)));
+
+        assertEquals(
+                points,
+                ListUtil.except(
+                        points,
+                        exclude,
+                        Comparator.comparing(Point::getY).thenComparing(Point::getX)));
+    }
+
+    @Test
+    void except_shouldExcludeUsingFieldValue() {
+        final List<Point> points = List.of(new Point(1, 2), new Point(3, 4));
+        final Point exclude = new Point(1, 4);
+
+        assertEquals(
+                List.of(new Point(3, 4)),
+                ListUtil.except(points, Collections.singletonList(exclude), Point::getX));
+
+        assertEquals(
+                List.of(new Point(1, 2)),
+                ListUtil.except(points, Collections.singletonList(exclude), Point::getY));
     }
 }


### PR DESCRIPTION
**`ListUtil`:**
- Make ListUtil a static class
  This doesn't need to be instantiated as it only contains static util methods
- Add tests

**OJ-2546:**
- Add list utility methods to use in SQS tests
  - Add a method to ListUtil to split a list into batches
  - Add a method to ListUtil to construct a list excluding elements from another list using a custom comparator
  - Add a method to ListUtil to exclude elements from a list using a custom comparator
  - Add a method to ListUtil to merge two lists without duplicating elements, using a custom comparator
  - Add a method to ListUtils to determine whether a list contains an object using a custom comparator