### PR TITLE
OJ-2546: Add a CloudFormation helper for integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ java {
 
 configurations {
 	aws
+	cloudformation
 	dynamodb
 	jackson
 	lambda
@@ -70,6 +71,8 @@ configurations.all {
 
 dependencies {
 	aws platform('software.amazon.awssdk:bom:2.20.162')
+
+	cloudformation "software.amazon.awssdk:cloudformation"
 
 	dynamodb "software.amazon.awssdk:dynamodb",
 			"software.amazon.awssdk:dynamodb-enhanced"
@@ -132,6 +135,7 @@ dependencies {
 
 	testFixturesApi configurations.aws
 	testFixturesApi configurations.sqs
+	testFixturesApi configurations.cloudformation
 	testFixturesApi	configurations.cucumber
 
 	testFixturesImplementation configurations.jackson

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/aws/CloudFormationHelper.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/aws/CloudFormationHelper.java
@@ -1,0 +1,81 @@
+package uk.gov.di.ipv.cri.common.library.aws;
+
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
+import software.amazon.awssdk.services.cloudformation.model.DescribeStacksRequest;
+import software.amazon.awssdk.services.cloudformation.model.DescribeStacksResponse;
+import software.amazon.awssdk.services.cloudformation.model.Stack;
+
+import java.security.InvalidParameterException;
+import java.util.List;
+
+/**
+ * A utility class to retrieve stack and it's outputs and parameters. The class is a wrapper around
+ * {@link CloudFormationClient} and allows to get around retrieving the mock SQS url used for tests
+ */
+public final class CloudFormationHelper {
+
+    /**
+     * Client for accessing AWS CloudFormation. All service calls made using this client are
+     * blocking, and will not return until the service call completes.
+     */
+    private static final CloudFormationClient cloudFormation = CloudFormationClient.create();
+
+    private CloudFormationHelper() {}
+
+    /**
+     * Returns the parameter data type from the stack. ParameterKey - The key associated with the
+     * parameter. If you don't specify a key and value for a particular parameter, AWS
+     * CloudFormation uses the default value that's specified in your template. ParameterValue - The
+     * input value associated with the parameter.
+     */
+    public static String getParameter(String stackName, String parameterName) {
+        return getStack(stackName).parameters().stream()
+                .filter(parameter -> parameter.parameterKey().equals(parameterName))
+                .findFirst()
+                .orElseThrow(
+                        () ->
+                                new InvalidParameterException(
+                                        String.format(
+                                                "Could not get parameter %s from stack %s",
+                                                parameterName, stackName)))
+                .parameterValue();
+    }
+
+    /**
+     * Returns the output data type from the stack. OutputKey - The key associated with the output.
+     * OutputValue - The value associated with the output.
+     */
+    public static String getOutput(String stackName, String outputName) {
+        Stack stack = getStack(stackName);
+
+        return stack.outputs().stream()
+                .filter(output -> output.outputKey().equals(outputName))
+                .findFirst()
+                .orElseThrow(
+                        () ->
+                                new InvalidParameterException(
+                                        String.format(
+                                                "Could not get output %s from stack %s",
+                                                outputName, stackName)))
+                .outputValue();
+    }
+
+    /**
+     * Returns the description for the specified stack; if no stack name was specified, then it
+     * returns the description for all the stacks created.
+     */
+    private static Stack getStack(String stackName) {
+        DescribeStacksRequest request =
+                DescribeStacksRequest.builder().stackName(stackName).build();
+
+        DescribeStacksResponse response = cloudFormation.describeStacks(request);
+
+        List<Stack> stacks = response.stacks();
+
+        if (stacks.isEmpty()) {
+            throw new IllegalArgumentException("Stack not found: " + stackName);
+        }
+
+        return stacks.get(0);
+    }
+}


### PR DESCRIPTION
## Proposed changes
CloudFrontHelper in Utils folder:

The helper allows to retrieve information from stacks, such as input or output values.

Created a  CloudFrontHelper class
[OJ-2546](https://govukverify.atlassian.net/browse/OJ-2546):

### What changed


Add CloudFormationClient method to use in SQS tests
Add a method to retrieve stack outputs key and values from cloudformation to use in SQS tests
Add a method to retrieve stack parameters key and values from cloudformation to use in SQS tests
Update dependency in build.gradle to use version 2.x

### Why did it change

To enable testing SQS in different CRIs

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2546]: https://govukverify.atlassian.net/browse/OJ-2546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ