### PR TITLE
OJ-2612: Add EvidenceRequest to Session

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 2.2.0
+
+* Made the SessionItem be able to access the `evidence_request` field 
+
 ## 2.1.0
 
 * Made the SQS helper test util work better with shared queues and multiple tests running at the same time

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "2.1.0"
+def buildVersion = "2.2.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/SessionRequest.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/SessionRequest.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.cri.common.library.domain;
 
 import com.nimbusds.jwt.SignedJWT;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.SharedClaims;
+import uk.gov.di.ipv.cri.common.library.persistence.item.EvidenceRequest;
 
 import java.net.URI;
 import java.util.Date;
@@ -23,6 +24,7 @@ public class SessionRequest {
     private String persistentSessionId;
     private String clientSessionId;
     private String clientIpAddress;
+    private EvidenceRequest evidenceRequest;
 
     public String getIssuer() {
         return issuer;
@@ -146,5 +148,13 @@ public class SessionRequest {
 
     public void setClientIpAddress(String clientIpAddress) {
         this.clientIpAddress = clientIpAddress;
+    }
+
+    public EvidenceRequest getEvidenceRequest() {
+        return evidenceRequest;
+    }
+
+    public void setEvidenceRequest(EvidenceRequest evidenceRequest) {
+        this.evidenceRequest = evidenceRequest;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/EvidenceRequest.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/EvidenceRequest.java
@@ -1,0 +1,69 @@
+package uk.gov.di.ipv.cri.common.library.persistence.item;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@DynamoDbBean
+public class EvidenceRequest {
+    private String scoringPolicy;
+    private int strengthScore;
+    private int validityScore;
+    private int verificationScore;
+    private int activityHistoryScore;
+    private int identityFraudScore;
+
+    public EvidenceRequest() {
+        // Empty constructor for Jackson
+    }
+
+    public String getScoringPolicy() {
+        return scoringPolicy;
+    }
+
+    public void setScoringPolicy(String scoringPolicy) {
+        this.scoringPolicy = scoringPolicy;
+    }
+
+    public int getStrengthScore() {
+        return strengthScore;
+    }
+
+    public void setStrengthScore(int strengthScore) {
+        this.strengthScore = strengthScore;
+    }
+
+    public int getValidityScore() {
+        return validityScore;
+    }
+
+    public void setValidityScore(int validityScore) {
+        this.validityScore = validityScore;
+    }
+
+    public int getVerificationScore() {
+        return verificationScore;
+    }
+
+    public void setVerificationScore(int verificationScore) {
+        this.verificationScore = verificationScore;
+    }
+
+    public int getActivityHistoryScore() {
+        return activityHistoryScore;
+    }
+
+    public void setActivityHistoryScore(int activityHistoryScore) {
+        this.activityHistoryScore = activityHistoryScore;
+    }
+
+    public int getIdentityFraudScore() {
+        return identityFraudScore;
+    }
+
+    public void setIdentityFraudScore(int identityFraudScore) {
+        this.identityFraudScore = identityFraudScore;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/SessionItem.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/SessionItem.java
@@ -26,6 +26,7 @@ public class SessionItem {
     private String clientSessionId;
     private String clientIpAddress;
     private int attemptCount;
+    private EvidenceRequest evidenceRequest;
 
     public SessionItem() {
         sessionId = UUID.randomUUID();
@@ -152,6 +153,14 @@ public class SessionItem {
 
     public void setAttemptCount(int attemptCount) {
         this.attemptCount = attemptCount;
+    }
+
+    public EvidenceRequest getEvidenceRequest() {
+        return evidenceRequest;
+    }
+
+    public void setEvidenceRequest(EvidenceRequest evidenceRequest) {
+        this.evidenceRequest = evidenceRequest;
     }
 
     @Override

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/persistence/SessionItemTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/persistence/SessionItemTest.java
@@ -1,0 +1,59 @@
+package uk.gov.di.ipv.cri.common.library.persistence;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.persistence.item.EvidenceRequest;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
+import uk.gov.di.ipv.cri.common.library.service.SessionService;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SessionItemTest {
+    @Mock private DataStore<SessionItem> dataStore;
+
+    @InjectMocks private SessionService sessionService;
+
+    private SessionItem sessionItem;
+
+    @BeforeEach
+    void setup() {
+        sessionItem = new SessionItem();
+        sessionItem.setSessionId(UUID.randomUUID());
+
+        EvidenceRequest evidenceRequest = new EvidenceRequest();
+        evidenceRequest.setScoringPolicy("gpg45");
+        evidenceRequest.setStrengthScore(2);
+        evidenceRequest.setValidityScore(3);
+        evidenceRequest.setVerificationScore(4);
+        evidenceRequest.setActivityHistoryScore(5);
+        evidenceRequest.setIdentityFraudScore(6);
+        sessionItem.setEvidenceRequest(evidenceRequest);
+
+        when(dataStore.getItem(any())).thenReturn(sessionItem);
+    }
+
+    @Test
+    void testGetSessionItem() {
+        SessionItem retrievedItem =
+                sessionService.getSession(sessionItem.getSessionId().toString());
+
+        EvidenceRequest evidenceRequest = sessionItem.getEvidenceRequest();
+
+        assertEquals(sessionItem.getSessionId(), retrievedItem.getSessionId());
+        assertEquals("gpg45", evidenceRequest.getScoringPolicy());
+        assertEquals(2, evidenceRequest.getStrengthScore());
+        assertEquals(3, evidenceRequest.getValidityScore());
+        assertEquals(4, evidenceRequest.getVerificationScore());
+        assertEquals(5, evidenceRequest.getActivityHistoryScore());
+        assertEquals(6, evidenceRequest.getIdentityFraudScore());
+    }
+}


### PR DESCRIPTION
## Proposed changes

### What changed
Sessions can have a optional `evidence_request` column in DynamoDB and so this PR ensures our SessionItem can access that column.

### Why did it change
For KBV CRI, we want the `verification_score` value from the `evidence_request` column to be within the VC.

### Issue tracking
- [OJ-2612:](https://govukverify.atlassian.net/browse/OJ-2612)
