### PR TITLE
BAU: Fix Javadoc warnings

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 2.2.1
+
+Fix Javadoc warnings
+
 ## 2.2.0
 
 * Made the SessionItem be able to access the `evidence_request` field 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "2.2.0"
+def buildVersion = "2.2.1"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/PersonIdentityDetailed.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/PersonIdentityDetailed.java
@@ -66,6 +66,7 @@ public class PersonIdentityDetailed {
      * @param addresses null list if not used
      * @param drivingPermits null list if not used
      * @param passports null list if not used
+     * @param socialSecurityRecords list of social security records
      * @deprecated Do not use outside CRI-Lib, CRI's should use PersonIdentityDetailedFactory with
      *     the appropriate createPersonIdentityDetailedWith methods.
      * @see uk.gov.di.ipv.cri.common.library.service.PersonIdentityDetailedFactory

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/ListUtil.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/ListUtil.java
@@ -23,6 +23,7 @@ public final class ListUtil {
     /**
      * Split a list into batches of specified size.
      *
+     * @param <T> The type of elements in the list
      * @param list The list to split into batches
      * @param batchSize The size of each batch. The last sublist will have between 1 and {@code
      *     batchSize} items
@@ -47,9 +48,13 @@ public final class ListUtil {
      * Create a new list comprised of elements in the {@code source} list except those in the {@code
      * except} when compared using a custom {@code mapper} function.
      *
+     * @param <T> The type of elements in the list
+     * @param <U> The type of elements resulting from the mapping function, which must be comparable
      * @param source The source list to filter
      * @param except The list containing the elements to exclude
      * @param mapper A function mapping list elements to values used to determine element equality
+     * @return A new list containing elements from the source list, excluding those that match any
+     *     elements in the except list
      */
     public static <T, U extends Comparable<? super U>> List<T> except(
             List<T> source, List<T> except, Function<? super T, ? extends U> mapper) {
@@ -57,9 +62,13 @@ public final class ListUtil {
     }
 
     /**
-     * Create a new list comprised of elements in the {@code source} list except those in the {@code
-     * except} when compared using a custom {@link Comparator comparator} function.
-     *
+     * @param <T> The type of elements in the list Create a new list comprised of elements in the
+     *     {@code source} list except those in the {@code except} when compared using a custom
+     *     {@link Comparator comparator} function.
+     * @param source The source list to filter
+     * @param except The items to not compare
+     * @param comparator the comparator to use
+     * @return a list of items
      * @see ListUtil#except(List, List, Function)
      */
     public static <T> List<T> except(List<T> source, List<T> except, Comparator<T> comparator) {
@@ -72,6 +81,8 @@ public final class ListUtil {
      * Modify the {@code source} list to remove the elements contained in the {@code except} list
      * using when compared using a custom {@code mapper} function.
      *
+     * @param <T> The type of elements in the list
+     * @param <U> The type of elements resulting from the mapping function, which must be comparable
      * @param source The source list to filter
      * @param except The list containing the elements to exclude
      * @param mapper A function mapping list elements to values used to determine element equality
@@ -85,6 +96,10 @@ public final class ListUtil {
      * Modify the {@code source} list to remove the elements contained in the {@code except} list
      * using when compared using a custom {@link Comparator comparator} function.
      *
+     * @param <T> the type of elements in the list
+     * @param source the source list
+     * @param except the items to not exclude
+     * @param comparator the comparator to use
      * @see ListUtil#exclude(List, List, Function)
      */
     public static <T> void exclude(List<T> source, List<T> except, Comparator<T> comparator) {
@@ -96,6 +111,8 @@ public final class ListUtil {
      * replaced by elements from the {@code merge} list if they are equal when evaluated using the
      * {@code mapper} function.
      *
+     * @param <T> The type of elements in the list
+     * @param <U> The type of elements to compare
      * @param source The source list to be modified with the new elements
      * @param merge The list with the elements to be added to the source list
      * @param mapper A function mapping list elements to values used to determine element equality
@@ -110,6 +127,9 @@ public final class ListUtil {
      * replaced by elements from the {@code merge} list if they are equal when evaluated using the
      * {@code comparator} function.
      *
+     * @param <T> The type of elements in the list
+     * @param source source the list into which elements are merged
+     * @param merge The list to add into source
      * @param comparator A {@link Comparator comparator} function used to determine element equality
      * @see ListUtil#mergeDistinct(List, List, Function)
      */
@@ -122,6 +142,7 @@ public final class ListUtil {
      * Determine whether a list contains an element using a custom comparator. This allows to select
      * only certain fields or specify a custom function to determine equality between objects.
      *
+     * @param <T> The type of elements in the list
      * @param list The source list to test for existence of the object
      * @param object Determine whether this object is an element of the list given the {@code
      *     comparator}


### PR DESCRIPTION
This PR fixes the Javadoc warnings that occur when running gradle build. The warnings are primarily, missing @param docs or @return docs