### PR TITLE
OJ-2612: Update shared claims to include Evidence Request parameters

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Credential Issuer common libraries Release Notes
 
+## 2.2.3
+* Added evidence request parameters to the shared claims endpoint to use verificationScore, strengthScore and strengthPolicy
+
 ## 2.2.2
 Testing of the automated publishing to Maven - no new changes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 # Credential Issuer common libraries Release Notes
 
 ## 2.2.3
-* Added evidence request parameters to the shared claims endpoint to use verificationScore, strengthScore and strengthPolicy
+* Added evidence request parameters to the shared claims endpoint to use verificationScore and strengthPolicy
 
 ## 2.2.2
 Testing of the automated publishing to Maven - no new changes

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "2.2.2"
+def buildVersion = "2.2.3"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/IpvCoreStubClient.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/IpvCoreStubClient.java
@@ -47,8 +47,7 @@ public class IpvCoreStubClient {
     }
 
     public String getClaimsForUserWithEvidenceRequested(
-            int userDataRowNumber, int verificationScore, int strengthScore)
-            throws IOException, InterruptedException {
+            int userDataRowNumber, int verificationScore) throws IOException, InterruptedException {
         URI uri =
                 new URIBuilder(this.clientConfigurationService.getIPVCoreStubURL())
                         .setPath("/backend/generateInitialClaimsSet")
@@ -56,7 +55,6 @@ public class IpvCoreStubClient {
                         .addParameter("rowNumber", String.valueOf(userDataRowNumber))
                         .addParameter("scoringPolicy", "gpg45")
                         .addParameter("verificationScore", String.valueOf(verificationScore))
-                        .addParameter("strengthScore", String.valueOf(strengthScore))
                         .build();
         HttpRequest request = HttpRequest.newBuilder().uri(uri).GET().build();
         return sendHttpRequest(request).body();

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/IpvCoreStubClient.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/IpvCoreStubClient.java
@@ -46,6 +46,22 @@ public class IpvCoreStubClient {
         return sendHttpRequest(request).body();
     }
 
+    public String getClaimsForUserWithEvidenceRequested(
+            int userDataRowNumber, int verificationScore, int strengthScore)
+            throws IOException, InterruptedException {
+        URI uri =
+                new URIBuilder(this.clientConfigurationService.getIPVCoreStubURL())
+                        .setPath("/backend/generateInitialClaimsSet")
+                        .addParameter("cri", clientConfigurationService.getIpvCoreStubCriId())
+                        .addParameter("rowNumber", String.valueOf(userDataRowNumber))
+                        .addParameter("scoringPolicy", "gpg45")
+                        .addParameter("verificationScore", String.valueOf(verificationScore))
+                        .addParameter("strengthScore", String.valueOf(strengthScore))
+                        .build();
+        HttpRequest request = HttpRequest.newBuilder().uri(uri).GET().build();
+        return sendHttpRequest(request).body();
+    }
+
     public String createSessionRequest(String requestBody)
             throws IOException, InterruptedException {
 

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CommonSteps.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CommonSteps.java
@@ -45,6 +45,19 @@ public class CommonSteps {
                         this.testContext.getSerialisedUserIdentity());
     }
 
+    @Given(
+            "user has the test-identity {int}, verificationScore of {int} and strengthScore of {int} in the form of a signed JWT string")
+    public void userHasTheTestIdentityVerificationScoreAndStrengthScoreInTheFormOfASignedJWTString(
+            int testUserDataSheetRowNumber, int verificationScore, int strengthScore)
+            throws IOException, InterruptedException {
+        this.testContext.setSerialisedUserIdentity(
+                this.ipvCoreStubClient.getClaimsForUserWithEvidenceRequested(
+                        testUserDataSheetRowNumber, verificationScore, strengthScore));
+        sessionRequestBody =
+                this.ipvCoreStubClient.createSessionRequest(
+                        this.testContext.getSerialisedUserIdentity());
+    }
+
     @When("user sends a POST request to session end point")
     public void userSendsAPostRequestToSessionEndpoint() throws IOException, InterruptedException {
 

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CommonSteps.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CommonSteps.java
@@ -46,13 +46,13 @@ public class CommonSteps {
     }
 
     @Given(
-            "user has the test-identity {int}, verificationScore of {int} and strengthScore of {int} in the form of a signed JWT string")
-    public void userHasTheTestIdentityVerificationScoreAndStrengthScoreInTheFormOfASignedJWTString(
-            int testUserDataSheetRowNumber, int verificationScore, int strengthScore)
+            "user has the test-identity {int} and verificationScore of {int} in the form of a signed JWT string")
+    public void userHasTheTestIdentityAndVerificationScoreInTheFormOfASignedJWTString(
+            int testUserDataSheetRowNumber, int verificationScore)
             throws IOException, InterruptedException {
         this.testContext.setSerialisedUserIdentity(
                 this.ipvCoreStubClient.getClaimsForUserWithEvidenceRequested(
-                        testUserDataSheetRowNumber, verificationScore, strengthScore));
+                        testUserDataSheetRowNumber, verificationScore));
         sessionRequestBody =
                 this.ipvCoreStubClient.createSessionRequest(
                         this.testContext.getSerialisedUserIdentity());


### PR DESCRIPTION
## Proposed changes
Updated shared claims endpoint to include evidence request parameters to update the verificationScore and strengthPolicy

### Why did it change

To enable integration tests in KBV CRI

### Issue tracking


- [OJ-2612](https://govukverify.atlassian.net/browse/OJ-2612)

## Checklists

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2612]: https://govukverify.atlassian.net/browse/OJ-2612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ