### PR TITLE
LIME-1071 Java SSM parameter and common service optimisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ infrastructure/lambda/samconfig.toml
 # intellij project dir
 .idea
 *.env
+
+# vscode
+.vscode

--- a/build.gradle
+++ b/build.gradle
@@ -10,16 +10,17 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "2.3.0"
+def buildVersion = "3.0.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 
 ext {
 	dependencyVersions = [
-		jackson_version          : "2.13.1",
+		aws_sdk_version          : "2.26.16",
 		aws_lambda_events_version: "3.11.6",
 		aws_powertools_version   : "1.18.0",
-		nimbusds_oauth_version   : "11.2",
+		jackson_version          : "2.17.2",
+		nimbusds_oauth_version   : "11.4",
 		nimbusds_jwt_version     : "9.36",
 		junit                    : "5.8.2",
 		mockito					 : "4.3.1",
@@ -43,6 +44,7 @@ java {
 
 configurations {
 	aws
+	aws_crt_client
 	cloudformation
 	dynamodb
 	jackson
@@ -62,14 +64,15 @@ configurations {
 	cucumber
 }
 
-// The dynamodb enhanced package loads the apache-client as well as the spi-client, so
-// we need to add the apache-client to the dependencies exclusion to not get a mismatch
 configurations.all {
+	// https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
 	exclude group:"software.amazon.awssdk", module: "apache-client"
+	exclude group:"software.amazon.awssdk", module: "netty-nio-client"
 }
 
 dependencies {
-	aws platform('software.amazon.awssdk:bom:2.20.162')
+	aws platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}")
+	aws_crt_client "software.amazon.awssdk:aws-crt-client:${dependencyVersions.aws_sdk_version}"
 
 	cloudformation "software.amazon.awssdk:cloudformation"
 
@@ -123,6 +126,7 @@ dependencies {
 			configurations.lambda,
 			configurations.jackson,
 			configurations.dynamodb,
+			configurations.aws_crt_client,
 			configurations.nimbus,
 			configurations.powertools,
 			configurations.sqs,

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/AccessTokenService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/AccessTokenService.java
@@ -46,8 +46,8 @@ public class AccessTokenService {
     }
 
     @ExcludeFromGeneratedCoverageReport
-    public AccessTokenService() {
-        this(new ConfigurationService(), new JWTVerifier());
+    public AccessTokenService(ConfigurationService configurationService) {
+        this(configurationService, new JWTVerifier());
     }
 
     public String getAuthorizationCode(TokenRequest tokenRequest) {

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditService.java
@@ -6,13 +6,10 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.utils.StringUtils;
-import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEvent;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventContext;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventType;
 import uk.gov.di.ipv.cri.common.library.exception.SqsException;
-
-import java.time.Clock;
 
 public class AuditService {
     private final SqsClient sqs;
@@ -20,33 +17,13 @@ public class AuditService {
     private final ObjectMapper objectMapper;
     private final AuditEventFactory auditEventFactory;
 
-    @ExcludeFromGeneratedCoverageReport
-    public AuditService() {
-        ConfigurationService configurationService = new ConfigurationService();
-        this.auditEventFactory = new AuditEventFactory(configurationService, Clock.systemUTC());
-        this.sqs = SqsClient.builder().build();
-        this.objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-        this.queueUrl = configurationService.getSqsAuditEventQueueUrl();
-        requireNonBlankQueueUrl();
-    }
-
-    @ExcludeFromGeneratedCoverageReport
-    public AuditService(ConfigurationService configurationService) {
-        this(
-                SqsClient.builder().build(),
-                configurationService,
-                new ObjectMapper().registerModule(new JavaTimeModule()),
-                new AuditEventFactory(configurationService, Clock.systemUTC()));
-        requireNonBlankQueueUrl();
-    }
-
     public AuditService(
             SqsClient sqs,
             ConfigurationService configurationService,
             ObjectMapper objectMapper,
             AuditEventFactory auditEventFactory) {
         this.sqs = sqs;
-        this.objectMapper = objectMapper;
+        this.objectMapper = objectMapper.registerModule(new JavaTimeModule());
         this.auditEventFactory = auditEventFactory;
         this.queueUrl = configurationService.getSqsAuditEventQueueUrl();
         requireNonBlankQueueUrl();

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityService.java
@@ -1,11 +1,11 @@
 package uk.gov.di.ipv.cri.common.library.service;
 
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.SharedClaims;
 import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
-import uk.gov.di.ipv.cri.common.library.persistence.DynamoDbEnhancedClientFactory;
 import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityItem;
 
 import java.util.UUID;
@@ -17,19 +17,9 @@ public class PersonIdentityService {
     private final DataStore<PersonIdentityItem> personIdentityDataStore;
 
     @ExcludeFromGeneratedCoverageReport
-    public PersonIdentityService() {
-        this.configurationService = new ConfigurationService();
-        this.personIdentityMapper = new PersonIdentityMapper();
-        this.personIdentityDataStore =
-                new DataStore<>(
-                        configurationService.getCommonParameterValue(
-                                PERSON_IDENTITY_TABLE_PARAM_NAME),
-                        PersonIdentityItem.class,
-                        new DynamoDbEnhancedClientFactory().getClient());
-    }
-
-    @ExcludeFromGeneratedCoverageReport
-    public PersonIdentityService(ConfigurationService configurationService) {
+    public PersonIdentityService(
+            ConfigurationService configurationService,
+            DynamoDbEnhancedClient dynamoDbEnhancedClient) {
         this(
                 new PersonIdentityMapper(),
                 configurationService,
@@ -37,7 +27,7 @@ public class PersonIdentityService {
                         configurationService.getCommonParameterValue(
                                 PERSON_IDENTITY_TABLE_PARAM_NAME),
                         PersonIdentityItem.class,
-                        new DynamoDbEnhancedClientFactory().getClient()));
+                        dynamoDbEnhancedClient));
     }
 
     public PersonIdentityService(

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.cri.common.library.service;
 
 import com.nimbusds.oauth2.sdk.token.AccessToken;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.lambda.powertools.logging.LoggingUtils;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.common.library.domain.SessionRequest;
@@ -9,7 +10,6 @@ import uk.gov.di.ipv.cri.common.library.exception.AuthorizationCodeExpiredExcept
 import uk.gov.di.ipv.cri.common.library.exception.SessionExpiredException;
 import uk.gov.di.ipv.cri.common.library.exception.SessionNotFoundException;
 import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
-import uk.gov.di.ipv.cri.common.library.persistence.DynamoDbEnhancedClientFactory;
 import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 import uk.gov.di.ipv.cri.common.library.util.ListUtil;
 
@@ -26,23 +26,14 @@ public class SessionService {
     private final Clock clock;
 
     @ExcludeFromGeneratedCoverageReport
-    public SessionService() {
-        this.configurationService = new ConfigurationService();
-        this.dataStore =
-                new DataStore<>(
-                        configurationService.getCommonParameterValue(SESSION_TABLE_PARAM_NAME),
-                        SessionItem.class,
-                        new DynamoDbEnhancedClientFactory().getClient());
-        this.clock = Clock.systemUTC();
-    }
-
-    @ExcludeFromGeneratedCoverageReport
-    public SessionService(ConfigurationService configurationService) {
+    public SessionService(
+            ConfigurationService configurationService,
+            DynamoDbEnhancedClient dynamoDbEnhancedClient) {
         this(
                 new DataStore<>(
                         configurationService.getCommonParameterValue(SESSION_TABLE_PARAM_NAME),
                         SessionItem.class,
-                        new DynamoDbEnhancedClientFactory().getClient()),
+                        dynamoDbEnhancedClient),
                 configurationService,
                 Clock.systemUTC());
     }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/ClientProviderFactory.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/ClientProviderFactory.java
@@ -1,0 +1,189 @@
+package uk.gov.di.ipv.cri.common.library.util;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.awscore.defaultsmode.DefaultsMode;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.lambda.powertools.parameters.ParamManager;
+import software.amazon.lambda.powertools.parameters.SSMProvider;
+import software.amazon.lambda.powertools.parameters.SecretsProvider;
+
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class ClientProviderFactory {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public static final String CONFIG_SERVICE_SSM_OPTIMIZED_CACHE_AGE_MIN_MINUTES =
+            "CONFIG_SERVICE_SSM_OPTIMIZED_CACHE_AGE_MIN_MINUTES";
+    public static final String CONFIG_SERVICE_SSM_OPTIMIZED_CACHE_AGE_MAX_MINUTES =
+            "CONFIG_SERVICE_SSM_OPTIMIZED_CACHE_AGE_MAX_MINUTES";
+
+    // https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/best-practices.html#bestpractice1
+    // https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/http-configuration.html
+    private final SdkHttpClient sdkHttpClient;
+    // https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/lambda-optimize-starttime.html
+    // https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
+    private final Region awsRegion;
+    private final EnvironmentVariableCredentialsProvider environmentVariableCredentialsProvider;
+
+    // https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/awscore/defaultsmode/DefaultsMode.html
+    // https://docs.aws.amazon.com/sdkref/latest/guide/feature-smart-config-defaults.html
+    // Optmize for within the same region
+    private static final DefaultsMode DEFAULTS_MODE = DefaultsMode.IN_REGION;
+
+    // All clients are Lazy init to prevent creating them when not used
+    private KmsClient kmsClient;
+    private SqsClient sqsClient;
+    private DynamoDbEnhancedClient dynamoDbEnhancedClient;
+    private SSMProvider ssmProvider;
+    private SecretsProvider secretsProvider;
+    private SecretsManagerClient secretsManagerClient;
+
+    public ClientProviderFactory() {
+        awsRegion = Region.of(System.getenv("AWS_REGION"));
+        // AWS SDK CRT Client (SYNC) - connection defaults are in SdkHttpConfigurationOption
+        sdkHttpClient = AwsCrtHttpClient.builder().maxConcurrency(100).build();
+        environmentVariableCredentialsProvider = EnvironmentVariableCredentialsProvider.create();
+    }
+
+    public KmsClient getKMSClient() {
+
+        if (null == kmsClient) {
+            kmsClient =
+                    KmsClient.builder()
+                            .region(awsRegion)
+                            .httpClient(sdkHttpClient)
+                            .credentialsProvider(environmentVariableCredentialsProvider)
+                            .defaultsMode(DEFAULTS_MODE)
+                            .build();
+        }
+
+        return kmsClient;
+    }
+
+    public SqsClient getSqsClient() {
+
+        if (null == sqsClient) {
+            sqsClient =
+                    SqsClient.builder()
+                            .region(awsRegion)
+                            .httpClient(sdkHttpClient)
+                            .credentialsProvider(environmentVariableCredentialsProvider)
+                            .defaultsMode(DEFAULTS_MODE)
+                            .build();
+        }
+
+        return sqsClient;
+    }
+
+    public DynamoDbEnhancedClient getDynamoDbEnhancedClient() {
+
+        if (null == dynamoDbEnhancedClient) {
+            DynamoDbClient dynamoDbClient =
+                    DynamoDbClient.builder()
+                            .region(awsRegion)
+                            .httpClient(sdkHttpClient)
+                            .credentialsProvider(environmentVariableCredentialsProvider)
+                            .defaultsMode(DEFAULTS_MODE)
+                            .build();
+
+            dynamoDbEnhancedClient =
+                    DynamoDbEnhancedClient.builder().dynamoDbClient(dynamoDbClient).build();
+        }
+
+        return dynamoDbEnhancedClient;
+    }
+
+    // ThreadLocalRandom not used cryptographically here
+    @java.lang.SuppressWarnings("java:S2245")
+    public SSMProvider getSSMProvider() {
+
+        if (null == ssmProvider) {
+            SsmClient ssmClient =
+                    SsmClient.builder()
+                            .region(awsRegion)
+                            .httpClient(sdkHttpClient)
+                            .credentialsProvider(environmentVariableCredentialsProvider)
+                            .defaultsMode(DEFAULTS_MODE)
+                            .build();
+
+            int maxAge = generateRandomMaxAgeInSeconds();
+
+            LOGGER.info("PowerTools SSMProvider defaultMaxAge selected as {} seconds", maxAge);
+
+            ssmProvider =
+                    ParamManager.getSsmProvider(ssmClient)
+                            .defaultMaxAge(maxAge, ChronoUnit.SECONDS);
+        }
+
+        return ssmProvider;
+    }
+
+    // ThreadLocalRandom not used cryptographically here
+    @java.lang.SuppressWarnings("java:S2245")
+    public SecretsProvider getSecretsProvider() {
+
+        if (null == secretsProvider) {
+
+            int maxAge = generateRandomMaxAgeInSeconds();
+
+            LOGGER.info("PowerTools SecretsProvider defaultMaxAge selected as {} seconds", maxAge);
+
+            secretsProvider =
+                    ParamManager.getSecretsProvider(getSecretsManagerClient())
+                            .defaultMaxAge(maxAge, ChronoUnit.SECONDS);
+        }
+        return secretsProvider;
+    }
+
+    // ThreadLocalRandom not used cryptographically here
+    @java.lang.SuppressWarnings("java:S2245")
+    private int generateRandomMaxAgeInSeconds() {
+        // If no values are set these are the fallback values
+        int minCacheAgeFallback = 5;
+        int maxCacheAgeFallback = 15;
+
+        int cacheMinMinutes =
+                System.getenv(CONFIG_SERVICE_SSM_OPTIMIZED_CACHE_AGE_MIN_MINUTES) != null
+                        ? Integer.parseInt(
+                                System.getenv(CONFIG_SERVICE_SSM_OPTIMIZED_CACHE_AGE_MIN_MINUTES))
+                        : minCacheAgeFallback;
+
+        int cacheMaxMinutes =
+                System.getenv(CONFIG_SERVICE_SSM_OPTIMIZED_CACHE_AGE_MAX_MINUTES) != null
+                        ? Integer.parseInt(
+                                System.getenv(CONFIG_SERVICE_SSM_OPTIMIZED_CACHE_AGE_MAX_MINUTES))
+                        : maxCacheAgeFallback;
+
+        int minCacheSeconds = cacheMinMinutes * 60;
+        int maxCacheSeconds = cacheMaxMinutes * 60;
+
+        return ThreadLocalRandom.current().nextInt(maxCacheSeconds - minCacheSeconds + 1)
+                + minCacheSeconds;
+    }
+
+    private SecretsManagerClient getSecretsManagerClient() {
+        if (null == secretsManagerClient) {
+            secretsManagerClient =
+                    SecretsManagerClient.builder()
+                            .region(awsRegion)
+                            .httpClient(sdkHttpClient)
+                            .credentialsProvider(environmentVariableCredentialsProvider)
+                            .defaultsMode(DEFAULTS_MODE)
+                            .build();
+        }
+
+        return secretsManagerClient;
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/AuditServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/AuditServiceTest.java
@@ -42,7 +42,8 @@ class AuditServiceTest {
     @BeforeEach
     void setup() {
         when(mockConfigurationService.getSqsAuditEventQueueUrl()).thenReturn(SQS_QUEUE_URL);
-        this.auditService =
+        when(mockObjectMapper.registerModule(any())).thenReturn(mockObjectMapper);
+        auditService =
                 new AuditService(
                         mockSqs, mockConfigurationService, mockObjectMapper, mockAuditEventFactory);
     }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java
@@ -1,19 +1,10 @@
 package uk.gov.di.ipv.cri.common.library.service;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
-import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
-import software.amazon.awssdk.services.ssm.SsmClient;
-import software.amazon.awssdk.services.ssm.SsmClientBuilder;
-import software.amazon.lambda.powertools.parameters.ParamManager;
 import software.amazon.lambda.powertools.parameters.SSMProvider;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
@@ -22,15 +13,10 @@ import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.cri.common.library.service.ConfigurationService.CONFIG_SERVICE_CACHE_TTL_MINS;
 
 @ExtendWith({MockitoExtension.class, SystemStubsExtension.class})
 class ConfigurationServiceTest {
@@ -145,64 +131,5 @@ class ConfigurationServiceTest {
         when(mockSsmProvider.get(PARAM_NAME)).thenReturn(PARAM_VALUE);
         assertEquals(PARAM_VALUE, configurationService.getParameterValueByAbsoluteName(PARAM_NAME));
         verify(mockSsmProvider).get(PARAM_NAME);
-    }
-
-    @Test
-    @DisplayName("should cache ssm params and secrets manager secrets for 5 minutes by default")
-    void shouldCacheFor5MinsByDefault() {
-        testConfigurationManagerWithExpectedCacheMinutes(5);
-    }
-
-    @Test
-    @DisplayName(
-            "should cache ssm params and secrets manager secrets for the number of minutes set by the env var "
-                    + CONFIG_SERVICE_CACHE_TTL_MINS)
-    void shouldCacheForMinutesSetByEnvVar() {
-        environment.set(CONFIG_SERVICE_CACHE_TTL_MINS, "1");
-        testConfigurationManagerWithExpectedCacheMinutes(1);
-    }
-
-    private void testConfigurationManagerWithExpectedCacheMinutes(int expectedMinutes) {
-        try (MockedStatic<ParamManager> mockStaticParamManager = mockStatic(ParamManager.class);
-                MockedStatic<SsmClient> mockStaticSsmClient = mockStatic(SsmClient.class);
-                MockedStatic<SecretsManagerClient> mockStaticSecretsManagerClient =
-                        mockStatic(SecretsManagerClient.class)) {
-
-            {
-                SsmClientBuilder mockSsmClientBuilder = mock(SsmClientBuilder.class);
-                mockStaticSsmClient.when(SsmClient::builder).thenReturn(mockSsmClientBuilder);
-                SsmClient mockSsmClient = mock(SsmClient.class);
-                when(mockSsmClientBuilder.region(Region.EU_WEST_2))
-                        .thenReturn(mockSsmClientBuilder);
-                when(mockSsmClientBuilder.httpClient(any(UrlConnectionHttpClient.class)))
-                        .thenReturn(mockSsmClientBuilder);
-                when(mockSsmClientBuilder.build()).thenReturn(mockSsmClient);
-                mockStaticParamManager
-                        .when(() -> ParamManager.getSsmProvider(mockSsmClient))
-                        .thenReturn(mockSsmProvider);
-            }
-
-            {
-                SecretsManagerClientBuilder mockSecretsManagerClientBuilder =
-                        mock(SecretsManagerClientBuilder.class);
-                SecretsManagerClient mockSecretsManagerClient = mock(SecretsManagerClient.class);
-                mockStaticSecretsManagerClient
-                        .when(SecretsManagerClient::builder)
-                        .thenReturn(mockSecretsManagerClientBuilder);
-                when(mockSecretsManagerClientBuilder.region(Region.EU_WEST_2))
-                        .thenReturn(mockSecretsManagerClientBuilder);
-                when(mockSecretsManagerClientBuilder.httpClient(any(UrlConnectionHttpClient.class)))
-                        .thenReturn(mockSecretsManagerClientBuilder);
-                when(mockSecretsManagerClientBuilder.build()).thenReturn(mockSecretsManagerClient);
-                mockStaticParamManager
-                        .when(() -> ParamManager.getSecretsProvider(mockSecretsManagerClient))
-                        .thenReturn(mockSecretsProvider);
-            }
-
-            new ConfigurationService();
-
-            verify(mockSsmProvider).defaultMaxAge(expectedMinutes, ChronoUnit.MINUTES);
-            verify(mockSecretsProvider).defaultMaxAge(expectedMinutes, ChronoUnit.MINUTES);
-        }
     }
 }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/ClientProviderFactoryTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/ClientProviderFactoryTest.java
@@ -1,0 +1,73 @@
+package uk.gov.di.ipv.cri.common.library.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.lambda.powertools.parameters.SSMProvider;
+import software.amazon.lambda.powertools.parameters.SecretsProvider;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
+class ClientProviderFactoryTest {
+    @SystemStub private EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+    private ClientProviderFactory clientProviderFactory;
+
+    @BeforeEach
+    void setUp() {
+        environmentVariables.set("AWS_REGION", "eu-west-2");
+        environmentVariables.set("AWS_STACK_NAME", "TEST_STACK");
+
+        clientProviderFactory = new ClientProviderFactory();
+    }
+
+    @Test
+    void shouldReturnKMSClient() {
+
+        KmsClient kmsClient = clientProviderFactory.getKMSClient();
+
+        assertNotNull(kmsClient);
+    }
+
+    @Test
+    void shouldReturnSqsClient() {
+
+        SqsClient sqsClient = clientProviderFactory.getSqsClient();
+
+        assertNotNull(sqsClient);
+    }
+
+    @Test
+    void shouldReturnDynamoDbEnhancedClient() {
+
+        DynamoDbEnhancedClient dynamoDbEnhancedClient =
+                clientProviderFactory.getDynamoDbEnhancedClient();
+
+        assertNotNull(dynamoDbEnhancedClient);
+    }
+
+    @Test
+    void shouldReturnSSMProvider() {
+
+        SSMProvider ssmProvider = clientProviderFactory.getSSMProvider();
+
+        assertNotNull(ssmProvider);
+    }
+
+    @Test
+    void shouldReturnSecretsProvider() {
+
+        SecretsProvider secretsProvider = clientProviderFactory.getSecretsProvider();
+
+        assertNotNull(secretsProvider);
+    }
+}


### PR DESCRIPTION
## Proposed changes

### What changed
	- Remove default constructors of
	- - ConfigurationService
	- - SessionService
	- - AccessTokenService
	- - AuditService

	Add ClientProviderFactory to enable a single source of clients for services
	Add AwsCrtHttpClient as dependancy and switch to it as the single http client used by all aws clients provided by ClientProviderFactory.
	ClientProviderFactory sets awsRegion, environmentVariableCredentialsProvider and defaultsMode on each client to reduce Java lambda start up times.
	ClientProviderFactory shares a single AwsCrtHttpClient with each client to further reduce reduce Java lambda start up times and resource usage.
	Clients provided by ClientProviderFactory can then be reused by any CRI specific services avoiding duplicate clients and sharing the same clients as the common services and reduce resource usage.

	Default constructors have been removed as
	- They where duplicating ConfigurationService which inturn duplicates an SSMProvider and Secrets provider
	- The internally where creating a service specfic client each with dedicated http client (which was being selected what ever was available from the classpath)

	- ConfigurationService - constructor changed to require SSMProviders and SecretsProvider
	- To allow sharing the same power tools cache in all common-services using ConfigurationService and allow CRI's to use the same SSMProviders/SecretsProvider also with the same cache.
	- The SSMProvider and SecretesProver have a randomized default max cache age per lambda context
	- Default is between 5mins and 15mins - configurble via environment variables.

	- Require SessionService (Dynamo), AuditService (SqsClient), AccessTokenService(Dynamo) to be provided a client to allow sharing where possible the same clients.

	- Removed feature flags set using parameter store variables (EXPIRY_REMOVED/ CONTAINS_UNIQUE_ID) - to remove some parameter reads
	- Now set via ENV vars ( ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED / ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID ) on the VC generating lambda - fallback behavour is the same if not set.

	- Exclude the netty-nio-client and apache-client now that the AwsCrtHttpClient is the only client in use
	- This needs replicated in any Java Lambdas to exclude them from the build step and reduce deployment size a small amount

	Updated AWS Dependancies
	- AWS SDK 2.20.162 -> 2.26.16
	- New Aws Crt Http Client aligned with AWS SDK 2.26.16
	- AWS Lambda Events 3.11.0 -> 3.11.6
	- AWS Lambda Powertools 1.12.0 -> 1.18.0
	- Nimbusds Oauth 11.3 -> 11.4

### Why did it change

To reduce object creation and aws service setup duplication with-in common and cri services that used a configuration service internally for setup.

This then allows AWS clients such as SSMProvider and SecretsProvider to be given a configurable default maxAge and for these providers to be shared with CRI code. Allows the parameter caching to be shared between the CRI and common services.

The common services also each had an underlying HTTP client (chosen from the class-path) - a http client was duplicated in every service for every aws service. The ClientProviderFactory sets up a single AwsCrtHttpClient, with this single AWS HTTP client used for all AWS services (per aws recommendations).

The objective being to reduce cold starts, reduce lambda run-time and mitigate lambdas hitting rate limits - either as lambdas are scaling or as caches expire.

### Issue tracking

- [LIME-1071](https://govukverify.atlassian.net/browse/LIME-1071)


[LIME-1071]: https://govukverify.atlassian.net/browse/LIME-1071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ