### PR TITLE
Release 3.0.1 - LIME-1071 Correct conflicting jackson dependencies

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Credential Issuer common libraries Release Notes
 
+## 3.0.1
+
+    Remove versions specified for the main Jackson dependencies and defer to the ones pull in from `software.amazon.awssdk:bom`. There is a breakage in a later jackson version, which crashes in the sdk classes which expect the older versions. 
+    Note : jackson-datatype-jsr310 and jackson-datatype-jdk8 are not in the aws sdk and are custom dependencies these version have been set at the aws pom versions to avoid a mismatch.
+
 ## 3.0.0
  ***BREAKING CHANGES***
  

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "3.0.0"
+def buildVersion = "3.0.1"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 
@@ -19,7 +19,7 @@ ext {
 		aws_sdk_version          : "2.26.16",
 		aws_lambda_events_version: "3.11.6",
 		aws_powertools_version   : "1.18.0",
-		jackson_version          : "2.17.2",
+		jackson_version          : "2.15.2", // Use AWS POM version only
 		nimbusds_oauth_version   : "11.4",
 		nimbusds_jwt_version     : "9.36",
 		junit                    : "5.8.2",
@@ -94,9 +94,9 @@ dependencies {
 
 	lambda_tests "software.amazon.awssdk:aws-lambda-java-tests:1.1.1"
 
-	jackson "com.fasterxml.jackson.core:jackson-core:${dependencyVersions.jackson_version}",
-			"com.fasterxml.jackson.core:jackson-databind:${dependencyVersions.jackson_version}",
-			"com.fasterxml.jackson.core:jackson-annotations:${dependencyVersions.jackson_version}",
+	jackson "com.fasterxml.jackson.core:jackson-core",
+			"com.fasterxml.jackson.core:jackson-databind",
+			"com.fasterxml.jackson.core:jackson-annotations",
 			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
 			"com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${dependencyVersions.jackson_version}"
 


### PR DESCRIPTION
## Proposed changes

### What changed

Remove versions specified for the main Jackson dependencies and defer to the ones pull in from `software.amazon.awssdk:bom`.

### Why did it change

There is a breakage in a later jackson version, which crashes in the sdk classes which expect the older versions. 

Note : jackson-datatype-jsr310 and jackson-datatype-jdk8 are not in the aws sdk and are custom dependencies these version have been set at the aws pom versions to avoid a mismatch.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1071](https://govukverify.atlassian.net/browse/LIME-1071)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[LIME-1071]: https://govukverify.atlassian.net/browse/LIME-1071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ