### PR TITLE
Release 3.0.2 - LIME-1071 Changed getSecretsManagerClient() to public in  ClientProviderFactory, inadvertently set as private when first added

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 3.0.2
+
+    Changed getSecretsManagerClient() to public in  ClientProviderFactory, inadvertently set as private when first added.
+
 ## 3.0.1
 
     Remove versions specified for the main Jackson dependencies and defer to the ones pull in from `software.amazon.awssdk:bom`. There is a breakage in a later jackson version, which crashes in the sdk classes which expect the older versions. 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "3.0.1"
+def buildVersion = "3.0.2"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/ClientProviderFactory.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/ClientProviderFactory.java
@@ -173,7 +173,7 @@ public class ClientProviderFactory {
                 + minCacheSeconds;
     }
 
-    private SecretsManagerClient getSecretsManagerClient() {
+    public SecretsManagerClient getSecretsManagerClient() {
         if (null == secretsManagerClient) {
             secretsManagerClient =
                     SecretsManagerClient.builder()

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/ClientProviderFactoryTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/ClientProviderFactoryTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.lambda.powertools.parameters.SSMProvider;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
@@ -69,5 +70,13 @@ class ClientProviderFactoryTest {
         SecretsProvider secretsProvider = clientProviderFactory.getSecretsProvider();
 
         assertNotNull(secretsProvider);
+    }
+
+    @Test
+    void shouldReturnSecretsManagerClient() {
+
+        SecretsManagerClient secretsManagerClient = clientProviderFactory.getSecretsManagerClient();
+
+        assertNotNull(secretsManagerClient);
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Changed getSecretsManagerClient() to public in  ClientProviderFactory

### Why did it change

Method was inadvertently set as private when first added.
Noticed when bringing in the changes to DL-API to use the SecretsManagerClient in secrete rotations.

### Issue tracking

- [LIME-1071](https://govukverify.atlassian.net/browse/LIME-1071)
