### PR TITLE
OJ-2650: add overrideJti to builder

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Credential Issuer common libraries Release Notes
+## 3.0.3
 
+    Added a overrideJti method to allow setting jti claims value in Contract-tests
 ## 3.0.2
 
     Changed getSecretsManagerClient() to public in  ClientProviderFactory, inadvertently set as private when first added.

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "3.0.2"
+def buildVersion = "3.0.3"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/SignedJWTFactory.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/SignedJWTFactory.java
@@ -5,8 +5,11 @@ import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+
+import java.text.ParseException;
 
 public class SignedJWTFactory {
     private final JWSSigner kmsSigner;
@@ -20,6 +23,17 @@ public class SignedJWTFactory {
         SignedJWT signedJWT = new SignedJWT(jwsHeader, claimsSet);
         signedJWT.sign(kmsSigner);
         return signedJWT;
+    }
+
+    public SignedJWT createSignedJwt(String claimsSet) throws ParseException, JOSEException {
+
+        SignedJWT signedJWT = new SignedJWT(generateHeader(), JWTClaimsSet.parse(claimsSet));
+        signedJWT.sign(kmsSigner);
+        Base64URL header = generateHeader().toBase64URL();
+        Base64URL payload = Base64URL.encode(claimsSet);
+
+        Base64URL signature = signedJWT.getSignature();
+        return new SignedJWT(header, payload, signature);
     }
 
     private JWSHeader generateHeader() {

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilder.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilder.java
@@ -30,6 +30,7 @@ public class VerifiableCredentialClaimsSetBuilder {
     private Object evidence;
     private ChronoUnit ttlUnit;
     private long ttl;
+    private JWTClaimsSet.Builder jwtClaimsSetBuilder;
 
     public VerifiableCredentialClaimsSetBuilder(
             ConfigurationService configurationService, Clock clock) {
@@ -102,7 +103,7 @@ public class VerifiableCredentialClaimsSetBuilder {
         OffsetDateTime dateTimeNow = OffsetDateTime.now(this.clock);
 
         JWTClaimsSet.Builder builder =
-                new JWTClaimsSet.Builder()
+                overrideJti()
                         .subject(this.subject)
                         .issuer(issuer)
                         .claim(JWTClaimNames.NOT_BEFORE, dateTimeNow.toEpochSecond());
@@ -130,6 +131,20 @@ public class VerifiableCredentialClaimsSetBuilder {
         builder.claim("vc", verifiableCredentialClaims);
 
         return builder.build();
+    }
+
+    public JWTClaimsSet.Builder overrideJti(String jti) {
+        if (System.getenv(ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID).equals("override")) {
+            return overrideJti().jwtID(jti);
+        }
+        return this.jwtClaimsSetBuilder;
+    }
+
+    private JWTClaimsSet.Builder overrideJti() {
+        if (this.jwtClaimsSetBuilder == null) {
+            this.jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
+        }
+        return this.jwtClaimsSetBuilder;
     }
 
     private boolean isReleaseFlag(String environmentVariable) {

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/SignedJWTFactoryTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/SignedJWTFactoryTest.java
@@ -30,13 +30,26 @@ class SignedJWTFactoryTest {
     private SignedJWTFactory signedJwtFactory;
 
     @Test
-    void shouldCreateASignedJwtSuccessfully()
+    void shouldCreateASignedJwtSuccessfullyFromJWTClaimsSet()
             throws JOSEException, InvalidKeySpecException, NoSuchAlgorithmException,
                     ParseException {
         JWTClaimsSet testClaimsSet = new JWTClaimsSet.Builder().build();
         signedJwtFactory = new SignedJWTFactory(new ECDSASigner(getPrivateKey()));
 
         SignedJWT signedJWT = signedJwtFactory.createSignedJwt(testClaimsSet);
+
+        assertThat(signedJWT.verify(new ECDSAVerifier(ECKey.parse(EC_PUBLIC_JWK_1))), is(true));
+    }
+
+    @Test
+    void shouldCreateASignedJwtSuccessfullyFromJWTClaimsSetString()
+            throws JOSEException, InvalidKeySpecException, NoSuchAlgorithmException,
+                    ParseException {
+        signedJwtFactory = new SignedJWTFactory(new ECDSASigner(getPrivateKey()));
+
+        SignedJWT signedJWT =
+                signedJwtFactory.createSignedJwt(
+                        "{\"iss\":\"dummyAddressComponentId\",\"sub\":\"test-subject\",\"nbf\":4070908800,\"exp\":4070909400,\"jti\":\"dummyJti\"}");
 
         assertThat(signedJWT.verify(new ECDSAVerifier(ECKey.parse(EC_PUBLIC_JWK_1))), is(true));
     }


### PR DESCRIPTION
## Proposed changes

Add a overrideJti method to the builder to allow access to the JwtClaimset in order to set dummy value for `jti` to help in contract tests
See: https://github.com/govuk-one-login/ipv-cri-address-api/blob/5cf485eb0ce5bc637accc1a2a8929153ee2235c6/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/SingleAddressBuildNumberVcTest.java#L107

### What changed

Contract testing means fixing certain values such as the `jti` which is randomly generated.

### Why did it change

Expected values for contract-test nbf, exp and jti can be specified as follows:


```
        environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID, "override");

        Clock clock = Clock.fixed(Instant.parse("2099-01-01T00:00:00.00Z"), ZoneId.of("UTC"));
        VerifiableCredentialClaimsSetBuilder claimsSetBuilder =
                new VerifiableCredentialClaimsSetBuilder(mockConfigurationService, clock);
        claimsSetBuilder.overrideJti("dummyJti");
```

as shown below, this would prevent having to amend the contract-test after it is generated

```
{
  "iss": "dummyAddressComponentId",
  "sub": "test-subject",
  "nbf": 4070908800,
  "exp": 4070909400,
  "vc": {...},
  "jti": "dummyJti"
}
```

Want to be able to specify overrides when the builder is created before it is passed onto the handler


- [OJ-2650:](https://govukverify.atlassian.net/browse/OJ-2650)

- [ ] Documented in the [README](./blob/main/README.md)
