### PR TITLE
LIME-1202 - Including Opaque KID in JWT headers for VCs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -48,6 +48,9 @@ AWS Lambda Powertools 1.12.0 -> 1.18.0
 
 Nimbusds Oauth 11.2 -> 11.4
 
+## 3.0.4
+Added methods to SignedJWTFactory to allow CRIs to add kid to jwt headers
+
 ## 2.3.0
 Added requested_verification_score from evidenceRequested to the logger in the SessionService
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "3.0.3"
+def buildVersion = "3.0.4"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/SignedJWTFactory.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/SignedJWTFactory.java
@@ -9,13 +9,27 @@ import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 
 public class SignedJWTFactory {
+
+    private static final String KID_PREFIX = "did:web:";
     private final JWSSigner kmsSigner;
 
     public SignedJWTFactory(JWSSigner kmsSigner) {
         this.kmsSigner = kmsSigner;
+    }
+
+    // Updated method for passing issuer used in building kid
+    public SignedJWT createSignedJwt(JWTClaimsSet claimsSet, String issuer, String keyId)
+            throws JOSEException, NoSuchAlgorithmException {
+        JWSHeader jwsHeader = generateHeader(issuer, keyId);
+        SignedJWT signedJWT = new SignedJWT(jwsHeader, claimsSet);
+        signedJWT.sign(kmsSigner);
+        return signedJWT;
     }
 
     public SignedJWT createSignedJwt(JWTClaimsSet claimsSet) throws JOSEException {
@@ -38,5 +52,27 @@ public class SignedJWTFactory {
 
     private JWSHeader generateHeader() {
         return new JWSHeader.Builder(JWSAlgorithm.ES256).type(JOSEObjectType.JWT).build();
+    }
+
+    // Updated method for passing issuer used in building kid
+    private JWSHeader generateHeader(String issuer, String signingKeyId)
+            throws NoSuchAlgorithmException {
+
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        byte[] hash = digest.digest(signingKeyId.getBytes(StandardCharsets.UTF_8));
+        String hashedKeyId = byteArrayToHex(hash);
+
+        String keyId = KID_PREFIX + issuer + ":" + hashedKeyId;
+
+        return new JWSHeader.Builder(JWSAlgorithm.ES256)
+                .type(JOSEObjectType.JWT)
+                .keyID(keyId)
+                .build();
+    }
+
+    private static String byteArrayToHex(byte[] a) {
+        StringBuilder sb = new StringBuilder(a.length * 2);
+        for (byte b : a) sb.append(String.format("%02x", b));
+        return sb.toString();
     }
 }


### PR DESCRIPTION
### What changed
 - Added new methods to SignedJWTFactory to allow CRIs to add opaque KID to JWT headers for VCs

### Why did it change

- As requested in RFC 83 - https://github.com/govuk-one-login/architecture/blob/main/adr/0083-publishing-signing-keys-for-vcs.md#key-resolution-and-the-web-did-method
