### PR TITLE
OJ-2720: Kid fix for JWT header

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,13 @@
 # Credential Issuer common libraries Release Notes
+
+## 3.0.5
+    Amend SignedJWTFactory generateHeaders: 
+    - Changed character prior to 'unique key identifier' from colon to hash so it is now {DID-method-specific identifier}#{unique key identifier}
+    - Strip https:// from the start of the issuer if present
+
+## 3.0.4
+    Added methods to SignedJWTFactory to allow CRIs to add kid to jwt headers
+
 ## 3.0.3
 
     Added a overrideJti method to allow setting jti claims value in Contract-tests
@@ -47,9 +56,6 @@ AWS Lambda Events 3.11.0 -> 3.11.6
 AWS Lambda Powertools 1.12.0 -> 1.18.0
 
 Nimbusds Oauth 11.2 -> 11.4
-
-## 3.0.4
-Added methods to SignedJWTFactory to allow CRIs to add kid to jwt headers
 
 ## 2.3.0
 Added requested_verification_score from evidenceRequested to the logger in the SessionService

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "3.0.4"
+def buildVersion = "3.0.5"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/SignedJWTFactory.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/SignedJWTFactory.java
@@ -58,11 +58,13 @@ public class SignedJWTFactory {
     private JWSHeader generateHeader(String issuer, String signingKeyId)
             throws NoSuchAlgorithmException {
 
+        issuer = issuer.replaceFirst("https://", "");
+
         MessageDigest digest = MessageDigest.getInstance("SHA-256");
         byte[] hash = digest.digest(signingKeyId.getBytes(StandardCharsets.UTF_8));
         String hashedKeyId = byteArrayToHex(hash);
 
-        String keyId = KID_PREFIX + issuer + ":" + hashedKeyId;
+        String keyId = KID_PREFIX + issuer + "#" + hashedKeyId;
 
         return new JWSHeader.Builder(JWSAlgorithm.ES256)
                 .type(JOSEObjectType.JWT)

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/SignedJWTFactoryTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/SignedJWTFactoryTest.java
@@ -1,7 +1,5 @@
 package uk.gov.di.ipv.cri.common.library.util;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.ECDSAVerifier;
@@ -30,6 +28,8 @@ class SignedJWTFactoryTest {
             "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgOXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthWhRANCAAQT1nO46ipxVTilUH2umZPN7OPI49GU6Y8YkcqLxFKUgypUzGbYR2VJGM+QJXk0PI339EyYkt6tjgfS+RcOMQNO";
     private static final String EC_PUBLIC_JWK_1 =
             "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}";
+    private static final String EXPECTED_KID =
+            "did:web:issuer#2078472f90d737929e5a580594dc563900af22b08161258760581e7f16b3d142";
     private SignedJWTFactory signedJwtFactory;
 
     @Test
@@ -67,24 +67,44 @@ class SignedJWTFactoryTest {
         SignedJWT signedJWT = signedJwtFactory.createSignedJwt(testClaimsSet, "issuer", "keyId");
 
         assertThat(signedJWT.verify(new ECDSAVerifier(ECKey.parse(EC_PUBLIC_JWK_1))), is(true));
+        assertEquals(EXPECTED_KID, signedJWT.getHeader().getKeyID());
     }
 
     @Test
     void shouldCreateASignedJwtSuccessfullyWithCorrectKeyIdStructure()
-            throws JOSEException, InvalidKeySpecException, NoSuchAlgorithmException,
-                    JsonProcessingException {
+            throws JOSEException, InvalidKeySpecException, NoSuchAlgorithmException {
         JWTClaimsSet testClaimsSet = new JWTClaimsSet.Builder().build();
         signedJwtFactory = new SignedJWTFactory(new ECDSASigner(getPrivateKey()));
 
         SignedJWT signedJWT = signedJwtFactory.createSignedJwt(testClaimsSet, "issuer", "keyId");
-        System.out.println(signedJWT.getHeader().getKeyID());
 
         String[] keyIDArray = signedJWT.getHeader().getKeyID().split(":");
 
-        System.out.println(new ObjectMapper().writeValueAsString(signedJWT));
         assertEquals("did", keyIDArray[0]);
         assertEquals("web", keyIDArray[1]);
-        assertEquals("issuer", keyIDArray[2]);
+        assertEquals(
+                "issuer#2078472f90d737929e5a580594dc563900af22b08161258760581e7f16b3d142",
+                keyIDArray[2]);
+        assertEquals(EXPECTED_KID, signedJWT.getHeader().getKeyID());
+    }
+
+    @Test
+    void shouldRemoveHttpsFromTheIssuerAndSuccessfullyCorrectKeyIdStructure()
+            throws JOSEException, InvalidKeySpecException, NoSuchAlgorithmException {
+        JWTClaimsSet testClaimsSet = new JWTClaimsSet.Builder().build();
+        signedJwtFactory = new SignedJWTFactory(new ECDSASigner(getPrivateKey()));
+
+        SignedJWT signedJWT =
+                signedJwtFactory.createSignedJwt(testClaimsSet, "https://issuer", "keyId");
+
+        String[] keyIDArray = signedJWT.getHeader().getKeyID().split(":");
+
+        assertEquals("did", keyIDArray[0]);
+        assertEquals("web", keyIDArray[1]);
+        assertEquals(
+                "issuer#2078472f90d737929e5a580594dc563900af22b08161258760581e7f16b3d142",
+                keyIDArray[2]);
+        assertEquals(EXPECTED_KID, signedJWT.getHeader().getKeyID());
     }
 
     private ECPrivateKey getPrivateKey() throws InvalidKeySpecException, NoSuchAlgorithmException {


### PR DESCRIPTION
KBV recently updated to use KID from the 3.0.4 update. Reported that the format was wrong as the issuer contained https:// and then a colon instead of a hash. Example - This will now produce: did:web:Issuer#HashedKeyID instead of did:web:Issuer:HashedKeyID

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

v.3.0.5

KBV recently updated to use KID from the 3.0.4 update. Reported that the format was wrong as the issuer contained https:// and then a colon instead of a hash. Example - This will now produce: did:web:Issuer#HashedKeyID instead of did:web:Issuer:HashedKeyID

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2720](https://govukverify.atlassian.net/browse/OJ-2720)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2720]: https://govukverify.atlassian.net/browse/OJ-2720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ