### PR TITLE
BAU: New `counterMetric` with unit parameter

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Credential Issuer common libraries Release Notes
 
+## 3.0.6
+    Added a new counterMetric method that accepts a Unit as an additional parameter.
+
 ## 3.0.5
     Amend SignedJWTFactory generateHeaders: 
     - Changed character prior to 'unique key identifier' from colon to hash so it is now {DID-method-specific identifier}#{unique key identifier}

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "3.0.5"
+def buildVersion = "3.0.6"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/EventProbe.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/EventProbe.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
+import software.amazon.cloudwatchlogs.emf.model.Unit;
 import software.amazon.lambda.powertools.logging.LoggingUtils;
 import software.amazon.lambda.powertools.metrics.MetricsUtils;
 
@@ -47,6 +48,11 @@ public class EventProbe {
 
     public EventProbe counterMetric(String key, double value) {
         METRICS_LOGGER.putMetric(key, value);
+        return this;
+    }
+
+    public EventProbe counterMetric(String key, double value, Unit unit) {
+        METRICS_LOGGER.putMetric(key, value, unit);
         return this;
     }
 


### PR DESCRIPTION
## Proposed changes

### What changed
Created a new method counterMetric that accepts a Unit as an additional parameter.

### Why did it change
There was no way for us to set the unit of a metrics e.g. seconds. 
