### PR TITLE
OJ-2812: Context field added to SessionRequest and SessionItem

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Credential Issuer common libraries Release Notes
 
+## 3.1.0
+    Added context field to SessionRequest and SessionItem. 
+
 ## 3.0.6
     Added a new counterMetric method that accepts a Unit as an additional parameter.
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "3.0.6"
+def buildVersion = "3.1.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/SessionRequest.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/SessionRequest.java
@@ -25,6 +25,7 @@ public class SessionRequest {
     private String clientSessionId;
     private String clientIpAddress;
     private EvidenceRequest evidenceRequest;
+    private String context;
 
     public String getIssuer() {
         return issuer;
@@ -156,5 +157,13 @@ public class SessionRequest {
 
     public void setEvidenceRequest(EvidenceRequest evidenceRequest) {
         this.evidenceRequest = evidenceRequest;
+    }
+
+    public String getContext() {
+        return context;
+    }
+
+    public void setContext(String context) {
+        this.context = context;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/SessionItem.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/SessionItem.java
@@ -27,6 +27,7 @@ public class SessionItem {
     private String clientIpAddress;
     private int attemptCount;
     private EvidenceRequest evidenceRequest;
+    private String context;
 
     public SessionItem() {
         sessionId = UUID.randomUUID();
@@ -161,6 +162,14 @@ public class SessionItem {
 
     public void setEvidenceRequest(EvidenceRequest evidenceRequest) {
         this.evidenceRequest = evidenceRequest;
+    }
+
+    public String getContext() {
+        return context;
+    }
+
+    public void setContext(String context) {
+        this.context = context;
     }
 
     @Override

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
@@ -60,6 +60,7 @@ public class SessionService {
         sessionItem.setClientSessionId(sessionRequest.getClientSessionId());
         sessionItem.setClientIpAddress(sessionRequest.getClientIpAddress());
         sessionItem.setAttemptCount(0);
+        sessionItem.setContext(sessionRequest.getContext());
         setSessionItemsToLogging(sessionItem);
 
         dataStore.create(sessionItem);

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/persistence/SessionItemTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/persistence/SessionItemTest.java
@@ -18,6 +18,8 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SessionItemTest {
+    private static final String INT_USER_CONTEXT = "international_user";
+
     @Mock private DataStore<SessionItem> dataStore;
 
     @InjectMocks private SessionService sessionService;
@@ -38,6 +40,8 @@ class SessionItemTest {
         evidenceRequest.setIdentityFraudScore(6);
         sessionItem.setEvidenceRequest(evidenceRequest);
 
+        sessionItem.setContext(INT_USER_CONTEXT);
+
         when(dataStore.getItem(any())).thenReturn(sessionItem);
     }
 
@@ -55,5 +59,7 @@ class SessionItemTest {
         assertEquals(4, evidenceRequest.getVerificationScore());
         assertEquals(5, evidenceRequest.getActivityHistoryScore());
         assertEquals(6, evidenceRequest.getIdentityFraudScore());
+
+        assertEquals(INT_USER_CONTEXT, sessionItem.getContext());
     }
 }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
@@ -43,6 +43,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class SessionServiceTest {
     private static final String SESSION_ID = UUID.randomUUID().toString();
+    private static final String INT_USER_CONTEXT = "international_user";
     private static Instant fixedInstant;
     private SessionService sessionService;
 
@@ -77,6 +78,7 @@ class SessionServiceTest {
         when(sessionRequest.getClientSessionId()).thenReturn("a client session id");
         when(sessionRequest.getClientIpAddress()).thenReturn("192.0.2.0");
         when(sessionRequest.getEvidenceRequest()).thenReturn(createEvidenceRequest());
+        when(sessionRequest.getContext()).thenReturn(INT_USER_CONTEXT);
 
         try (MockedStatic<LoggingUtils> loggingUtilsMockedStatic =
                 Mockito.mockStatic(LoggingUtils.class)) {
@@ -97,6 +99,7 @@ class SessionServiceTest {
                 capturedValue.getRedirectUri(),
                 equalTo(URI.create("https://www.example.com/callback")));
         assertThat(capturedValue.getAttemptCount(), equalTo(0));
+        assertThat(capturedValue.getContext(), equalTo(INT_USER_CONTEXT));
     }
 
     @Test

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
@@ -67,18 +67,16 @@ class SessionServiceTest {
         final long sessionExpirationEpoch = 10L;
         when(mockConfigurationService.getSessionExpirationEpoch())
                 .thenReturn(sessionExpirationEpoch);
-        SessionRequest sessionRequest = mock(SessionRequest.class);
-
-        when(sessionRequest.getClientId()).thenReturn("a client id");
-        when(sessionRequest.getState()).thenReturn("state");
-        when(sessionRequest.getRedirectUri())
-                .thenReturn(URI.create("https://www.example.com/callback"));
-        when(sessionRequest.getSubject()).thenReturn("a subject");
-        when(sessionRequest.getPersistentSessionId()).thenReturn("a persistent session id");
-        when(sessionRequest.getClientSessionId()).thenReturn("a client session id");
-        when(sessionRequest.getClientIpAddress()).thenReturn("192.0.2.0");
-        when(sessionRequest.getEvidenceRequest()).thenReturn(createEvidenceRequest());
-        when(sessionRequest.getContext()).thenReturn(INT_USER_CONTEXT);
+        SessionRequest sessionRequest = new SessionRequest();
+        sessionRequest.setClientId("a client id");
+        sessionRequest.setState("state");
+        sessionRequest.setRedirectUri(URI.create("https://www.example.com/callback"));
+        sessionRequest.setSubject("a subject");
+        sessionRequest.setPersistentSessionId("a persistent session id");
+        sessionRequest.setClientSessionId("a client session id");
+        sessionRequest.setClientIpAddress("192.0.2.0");
+        sessionRequest.setEvidenceRequest(createEvidenceRequest());
+        sessionRequest.setContext(INT_USER_CONTEXT);
 
         try (MockedStatic<LoggingUtils> loggingUtilsMockedStatic =
                 Mockito.mockStatic(LoggingUtils.class)) {
@@ -89,17 +87,19 @@ class SessionServiceTest {
         SessionItem capturedValue = sessionItemArgumentCaptor.getValue();
         assertNotNull(capturedValue.getSessionId());
         assertThat(capturedValue.getExpiryDate(), equalTo(sessionExpirationEpoch));
-        assertThat(capturedValue.getClientId(), equalTo("a client id"));
-        assertThat(capturedValue.getState(), equalTo("state"));
-        assertThat(capturedValue.getSubject(), equalTo("a subject"));
-        assertThat(capturedValue.getPersistentSessionId(), equalTo("a persistent session id"));
-        assertThat(capturedValue.getClientSessionId(), equalTo("a client session id"));
-        assertThat(capturedValue.getClientIpAddress(), equalTo("192.0.2.0"));
+        assertThat(capturedValue.getClientId(), equalTo(sessionRequest.getClientId()));
+        assertThat(capturedValue.getState(), equalTo(sessionRequest.getState()));
+        assertThat(capturedValue.getSubject(), equalTo(sessionRequest.getSubject()));
         assertThat(
-                capturedValue.getRedirectUri(),
-                equalTo(URI.create("https://www.example.com/callback")));
+                capturedValue.getPersistentSessionId(),
+                equalTo(sessionRequest.getPersistentSessionId()));
+        assertThat(
+                capturedValue.getClientSessionId(), equalTo(sessionRequest.getClientSessionId()));
+        assertThat(
+                capturedValue.getClientIpAddress(), equalTo(sessionRequest.getClientIpAddress()));
+        assertThat(capturedValue.getRedirectUri(), equalTo(sessionRequest.getRedirectUri()));
         assertThat(capturedValue.getAttemptCount(), equalTo(0));
-        assertThat(capturedValue.getContext(), equalTo(INT_USER_CONTEXT));
+        assertThat(capturedValue.getContext(), equalTo(sessionRequest.getContext()));
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
Context field added to SessionRequest and SessionItem.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
To allow context claims to be stored with the session. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2812](https://govukverify.atlassian.net/browse/OJ-2812)


[OJ-2812]: https://govukverify.atlassian.net/browse/OJ-2812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ