### PR TITLE
LIME-1271 - Updating PersonIdentity Mapper to map driving permit when…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # Credential Issuer common libraries Release Notes
 
+## 3.1.1
+    - Updated drivingPermit model to include fullAddress
+    - Updated PersonIdentity to include DrivingPermit
+    - Updated SharedClaims to include DrivingPermit
+    - Created PersonIdentityDrivingPermit Dynamo Bean and added this to personIdentity for mapping purposes
+    - Updated PersonIdentityMapper to map drivingPermit in shared claims to the PersonIdentity
+
 ## 3.1.0
     Added context field to SessionRequest and SessionItem. 
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "3.1.0"
+def buildVersion = "3.1.1"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/DrivingPermit.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/DrivingPermit.java
@@ -23,6 +23,9 @@ public class DrivingPermit {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private String issueDate;
 
+    @JsonProperty("fullAddress")
+    private String fullAddress;
+
     public String getPersonalNumber() {
         return personalNumber;
     }
@@ -61,5 +64,13 @@ public class DrivingPermit {
 
     public void setIssueDate(String issueDate) {
         this.issueDate = issueDate;
+    }
+
+    public String getFullAddress() {
+        return fullAddress;
+    }
+
+    public void setFullAddress(String fullAddress) {
+        this.fullAddress = fullAddress;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/PersonIdentity.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/PersonIdentity.java
@@ -16,6 +16,7 @@ public class PersonIdentity {
     private String surname;
     private List<Address> addresses;
     private List<SocialSecurityRecord> socialSecurityRecords;
+    private List<DrivingPermit> drivingPermits;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate dateOfBirth;
@@ -70,5 +71,13 @@ public class PersonIdentity {
 
     public void setSocialSecurityRecord(List<SocialSecurityRecord> socialSecurityRecord) {
         this.socialSecurityRecords = socialSecurityRecord;
+    }
+
+    public List<DrivingPermit> getDrivingPermits() {
+        return drivingPermits;
+    }
+
+    public void setDrivingPermits(List<DrivingPermit> drivingPermits) {
+        this.drivingPermits = drivingPermits;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/SharedClaims.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/SharedClaims.java
@@ -24,6 +24,9 @@ public class SharedClaims {
     @JsonProperty("address")
     private List<Address> addresses;
 
+    @JsonProperty("drivingPermit")
+    private List<DrivingPermit> drivingPermits;
+
     public List<Name> getNames() {
         return names;
     }
@@ -62,5 +65,13 @@ public class SharedClaims {
 
     public void setSocialSecurityRecords(List<SocialSecurityRecord> socialSecurityRecords) {
         this.socialSecurityRecords = socialSecurityRecords;
+    }
+
+    public List<DrivingPermit> getDrivingPermits() {
+        return drivingPermits;
+    }
+
+    public void setDrivingPermits(List<DrivingPermit> drivingPermits) {
+        this.drivingPermits = drivingPermits;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/personidentity/PersonIdentityDrivingPermit.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/personidentity/PersonIdentityDrivingPermit.java
@@ -1,0 +1,75 @@
+package uk.gov.di.ipv.cri.common.library.persistence.item.personidentity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@DynamoDbBean
+public class PersonIdentityDrivingPermit {
+    private String personalNumber;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private String expiryDate;
+
+    private String issueNumber;
+
+    private String issuedBy;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private String issueDate;
+
+    private String fullAddress;
+
+    public PersonIdentityDrivingPermit() {
+        // Default constructor
+    }
+
+    public String getIssueDate() {
+        return issueDate;
+    }
+
+    public void setIssueDate(String issueDate) {
+        this.issueDate = issueDate;
+    }
+
+    public String getIssuedBy() {
+        return issuedBy;
+    }
+
+    public void setIssuedBy(String issuedBy) {
+        this.issuedBy = issuedBy;
+    }
+
+    public String getIssueNumber() {
+        return issueNumber;
+    }
+
+    public void setIssueNumber(String issueNumber) {
+        this.issueNumber = issueNumber;
+    }
+
+    public String getExpiryDate() {
+        return expiryDate;
+    }
+
+    public void setExpiryDate(String expiryDate) {
+        this.expiryDate = expiryDate;
+    }
+
+    public String getPersonalNumber() {
+        return personalNumber;
+    }
+
+    public void setPersonalNumber(String personalNumber) {
+        this.personalNumber = personalNumber;
+    }
+
+    public String getFullAddress() {
+        return fullAddress;
+    }
+
+    public void setFullAddress(String fullAddress) {
+        this.fullAddress = fullAddress;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/personidentity/PersonIdentityItem.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/personidentity/PersonIdentityItem.java
@@ -15,6 +15,7 @@ public class PersonIdentityItem {
     private List<PersonIdentityDateOfBirth> birthDates;
     private long expiryDate;
     private List<PersonIdentitySocialSecurityRecord> socialSecurityRecords;
+    private List<PersonIdentityDrivingPermit> drivingPermits;
 
     @DynamoDbPartitionKey()
     public UUID getSessionId() {
@@ -64,5 +65,13 @@ public class PersonIdentityItem {
     public void setSocialSecurityRecords(
             List<PersonIdentitySocialSecurityRecord> socialSecurityRecords) {
         this.socialSecurityRecords = socialSecurityRecords;
+    }
+
+    public List<PersonIdentityDrivingPermit> getDrivingPermits() {
+        return drivingPermits;
+    }
+
+    public void setDrivingPermits(List<PersonIdentityDrivingPermit> drivingPermits) {
+        this.drivingPermits = drivingPermits;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapper.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapper.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.cri.common.library.service;
 
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.BirthDate;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.DrivingPermit;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Name;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.NamePart;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
@@ -10,6 +11,7 @@ import uk.gov.di.ipv.cri.common.library.domain.personidentity.SharedClaims;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.SocialSecurityRecord;
 import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
 import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityDateOfBirth;
+import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityDrivingPermit;
 import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityItem;
 import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityName;
 import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityNamePart;
@@ -49,6 +51,10 @@ public class PersonIdentityMapper {
             identity.setSocialSecurityRecords(
                     mapSocialSecurityRecords(sharedClaims.getSocialSecurityRecords()));
         }
+        if (notNullAndNotEmpty(sharedClaims.getDrivingPermits())) {
+            identity.setDrivingPermits(
+                    mapPersonIdentityDrivingPermits(sharedClaims.getDrivingPermits()));
+        }
         return identity;
     }
 
@@ -70,6 +76,11 @@ public class PersonIdentityMapper {
         if (notNullAndNotEmpty(personIdentityItem.getSocialSecurityRecords())) {
             personIdentity.setSocialSecurityRecord(
                     mapSocialSecurityRecord(personIdentityItem.getSocialSecurityRecords()));
+        }
+
+        if (notNullAndNotEmpty(personIdentityItem.getDrivingPermits())) {
+            personIdentity.setDrivingPermits(
+                    mapDrivingPermits(personIdentityItem.getDrivingPermits()));
         }
 
         return personIdentity;
@@ -116,6 +127,13 @@ public class PersonIdentityMapper {
             socialSecurityRecords =
                     mapPersonIdentitySocialSecurityRecords(
                             personIdentityItem.getSocialSecurityRecords());
+        }
+
+        List<DrivingPermit> drivingPermits = Collections.emptyList();
+        if (notNullAndNotEmpty(personIdentityItem.getDrivingPermits())) {
+            drivingPermits = mapDrivingPermits(personIdentityItem.getDrivingPermits());
+            return PersonIdentityDetailedFactory.createPersonIdentityDetailedWithDrivingPermit(
+                    names, dobs, addresses, drivingPermits);
         }
 
         return PersonIdentityDetailedFactory.createPersonIdentityDetailedWithAddresses(
@@ -176,6 +194,25 @@ public class PersonIdentityMapper {
                             mappedSocialRecord.setPersonalNumber(
                                     securityRecord.getPersonalNumber());
                             return mappedSocialRecord;
+                        })
+                .collect(Collectors.toList());
+    }
+
+    private List<PersonIdentityDrivingPermit> mapPersonIdentityDrivingPermits(
+            List<DrivingPermit> drivingPermits) {
+        return drivingPermits.stream()
+                .map(
+                        drivingPermit -> {
+                            PersonIdentityDrivingPermit mappedDrivingPermit =
+                                    new PersonIdentityDrivingPermit();
+                            mappedDrivingPermit.setPersonalNumber(
+                                    drivingPermit.getPersonalNumber());
+                            mappedDrivingPermit.setExpiryDate(drivingPermit.getExpiryDate());
+                            mappedDrivingPermit.setIssueDate(drivingPermit.getIssueDate());
+                            mappedDrivingPermit.setIssueNumber(drivingPermit.getIssueNumber());
+                            mappedDrivingPermit.setIssuedBy(drivingPermit.getIssuedBy());
+                            mappedDrivingPermit.setFullAddress(drivingPermit.getFullAddress());
+                            return mappedDrivingPermit;
                         })
                 .collect(Collectors.toList());
     }
@@ -326,6 +363,26 @@ public class PersonIdentityMapper {
                                     new PersonIdentitySocialSecurityRecord();
                             personalNumber.setPersonalNumber(sr.getPersonalNumber());
                             return personalNumber;
+                        })
+                .collect(Collectors.toList());
+    }
+
+    private List<DrivingPermit> mapDrivingPermits(
+            List<PersonIdentityDrivingPermit> drivingPermits) {
+        return drivingPermits.stream()
+                .map(
+                        dp -> {
+                            DrivingPermit drivingPermit = new DrivingPermit();
+                            drivingPermit.setPersonalNumber(dp.getPersonalNumber());
+                            drivingPermit.setExpiryDate(dp.getExpiryDate());
+                            drivingPermit.setIssueDate(dp.getIssueDate());
+                            if (Objects.nonNull(dp.getIssueNumber())) {
+                                drivingPermit.setIssueNumber(dp.getIssueNumber());
+                            }
+                            drivingPermit.setIssuedBy(dp.getIssuedBy());
+                            drivingPermit.setFullAddress(dp.getFullAddress());
+
+                            return drivingPermit;
                         })
                 .collect(Collectors.toList());
     }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapperTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapperTest.java
@@ -7,6 +7,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.BirthDate;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.DrivingPermit;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Name;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.NamePart;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
@@ -15,6 +16,7 @@ import uk.gov.di.ipv.cri.common.library.domain.personidentity.SharedClaims;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.SocialSecurityRecord;
 import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
 import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityDateOfBirth;
+import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityDrivingPermit;
 import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityItem;
 import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityName;
 import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityNamePart;
@@ -208,6 +210,16 @@ class PersonIdentityMapperTest {
         socialSecurityRecord.setPersonalNumber("AA000003D");
         sharedClaims.setSocialSecurityRecords(List.of(socialSecurityRecord));
 
+        DrivingPermit drivingPermit = new DrivingPermit();
+        drivingPermit.setPersonalNumber("personalNumber");
+        drivingPermit.setExpiryDate(LocalDate.of(2029, 10, 21).toString());
+        drivingPermit.setIssueDate(LocalDate.of(2011, 10, 21).toString());
+        drivingPermit.setIssueNumber("issueNumber");
+        drivingPermit.setIssuedBy("issuedBy");
+        drivingPermit.setFullAddress("full address");
+
+        sharedClaims.setDrivingPermits(List.of(drivingPermit));
+
         PersonIdentityItem mappedPersonIdentityItem =
                 personIdentityMapper.mapToPersonIdentityItem(sharedClaims);
 
@@ -215,6 +227,8 @@ class PersonIdentityMapperTest {
         CanonicalAddress mappedAddress = mappedPersonIdentityItem.getAddresses().get(0);
         PersonIdentitySocialSecurityRecord mappedSocialSecurityRecord =
                 mappedPersonIdentityItem.getSocialSecurityRecords().get(0);
+        PersonIdentityDrivingPermit mappedDrivingPermit =
+                mappedPersonIdentityItem.getDrivingPermits().get(0);
 
         assertEquals(firstNamePart.getValue(), mappedName.getNameParts().get(0).getValue());
         assertEquals(firstNamePart.getType(), mappedName.getNameParts().get(0).getType());
@@ -232,6 +246,13 @@ class PersonIdentityMapperTest {
         assertEquals(
                 socialSecurityRecord.getPersonalNumber(),
                 mappedSocialSecurityRecord.getPersonalNumber());
+
+        assertEquals(drivingPermit.getPersonalNumber(), mappedDrivingPermit.getPersonalNumber());
+        assertEquals(drivingPermit.getExpiryDate(), mappedDrivingPermit.getExpiryDate());
+        assertEquals(drivingPermit.getIssueDate(), mappedDrivingPermit.getIssueDate());
+        assertEquals(drivingPermit.getIssueNumber(), mappedDrivingPermit.getIssueNumber());
+        assertEquals(drivingPermit.getIssuedBy(), mappedDrivingPermit.getIssuedBy());
+        assertEquals(drivingPermit.getFullAddress(), mappedDrivingPermit.getFullAddress());
     }
 
     @Test
@@ -269,12 +290,21 @@ class PersonIdentityMapperTest {
                 new PersonIdentitySocialSecurityRecord();
         personIdentitySocialSecurityRecord.setPersonalNumber("AA000003D");
 
+        PersonIdentityDrivingPermit personIdentityDrivingPermit = new PersonIdentityDrivingPermit();
+        personIdentityDrivingPermit.setPersonalNumber("personalNumber");
+        personIdentityDrivingPermit.setExpiryDate(LocalDate.of(2029, 10, 21).toString());
+        personIdentityDrivingPermit.setIssueDate(LocalDate.of(2011, 10, 21).toString());
+        personIdentityDrivingPermit.setIssueNumber("issueNumber");
+        personIdentityDrivingPermit.setIssuedBy("issuedBy");
+        personIdentityDrivingPermit.setFullAddress("fullAddress");
+
         PersonIdentityItem testPersonIdentityItem = new PersonIdentityItem();
         testPersonIdentityItem.setNames(List.of(name));
         testPersonIdentityItem.setBirthDates(List.of(birthDate));
         testPersonIdentityItem.setAddresses(List.of(address));
         testPersonIdentityItem.setSocialSecurityRecords(
                 List.of(personIdentitySocialSecurityRecord));
+        testPersonIdentityItem.setDrivingPermits(List.of(personIdentityDrivingPermit));
 
         PersonIdentityDetailed mappedPersonIdentity =
                 personIdentityMapper.mapToPersonIdentityDetailed(testPersonIdentityItem);
@@ -303,6 +333,20 @@ class PersonIdentityMapperTest {
         assertEquals(address.getStreetName(), mappedAddress.getStreetName());
         assertEquals(address.getSubBuildingName(), mappedAddress.getSubBuildingName());
         assertEquals(address.getUprn(), mappedAddress.getUprn());
+
+        DrivingPermit mappedDrivingPermit = mappedPersonIdentity.getDrivingPermits().get(0);
+        assertEquals(
+                personIdentityDrivingPermit.getPersonalNumber(),
+                mappedDrivingPermit.getPersonalNumber());
+        assertEquals(
+                personIdentityDrivingPermit.getExpiryDate(), mappedDrivingPermit.getExpiryDate());
+        assertEquals(
+                personIdentityDrivingPermit.getIssueDate(), mappedDrivingPermit.getIssueDate());
+        assertEquals(
+                personIdentityDrivingPermit.getIssueNumber(), mappedDrivingPermit.getIssueNumber());
+        assertEquals(personIdentityDrivingPermit.getIssuedBy(), mappedDrivingPermit.getIssuedBy());
+        assertEquals(
+                personIdentityDrivingPermit.getFullAddress(), mappedDrivingPermit.getFullAddress());
 
         // CRIs using a java backend currently shouldn't have a nino sent to them,
         // functionality has been added in case this changes in the future but for now


### PR DESCRIPTION
### What changed
 - Updated drivingPermit model to include fullAddress
 - Updated PersonIdentity to include DrivingPermit
 - Updated SharedClaims to include DrivingPermit
 - Created PersonIdentityDrivingPermit Dynamo Bean and added this to personIdentity for mapping purposes
 - Updated PersonIdentityMapper to map drivingPermit in shared claims to the PersonIdentity
 - Updated Tests