### PR TITLE
OJ-2813: add user identity with context

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # Credential Issuer common libraries Release Notes
 
+## 3.1.2
+    - Refactor getClaimsForUser to allow single parameter
+    - Removed original getClaimsForUser, use new getClaimsForUser
+    - Removed getClaimsForUserWithEvidenceRequested, use new getClaimsForUser
+    - Added new commonsstep for user with a context
+
+
 ## 3.1.1
     - Updated drivingPermit model to include fullAddress
     - Updated PersonIdentity to include DrivingPermit

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "3.1.1"
+def buildVersion = "3.1.2"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/IpvCoreStubClient.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/IpvCoreStubClient.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.Map;
 
 public class IpvCoreStubClient {
     private static final String JSON_MIME_MEDIA_TYPE = "application/json";
@@ -35,28 +36,17 @@ public class IpvCoreStubClient {
                         .build();
     }
 
-    public String getClaimsForUser(int userDataRowNumber) throws IOException, InterruptedException {
-        URI uri =
+    public String getClaimsForUser(Map<String, String> parameters)
+            throws IOException, InterruptedException {
+        URIBuilder uriBuilder =
                 new URIBuilder(this.clientConfigurationService.getIPVCoreStubURL())
-                        .setPath("/backend/generateInitialClaimsSet")
-                        .addParameter("cri", clientConfigurationService.getIpvCoreStubCriId())
-                        .addParameter("rowNumber", String.valueOf(userDataRowNumber))
-                        .build();
-        HttpRequest request = HttpRequest.newBuilder().uri(uri).GET().build();
-        return sendHttpRequest(request).body();
-    }
+                        .setPath("/backend/generateInitialClaimsSet");
 
-    public String getClaimsForUserWithEvidenceRequested(
-            int userDataRowNumber, int verificationScore) throws IOException, InterruptedException {
-        URI uri =
-                new URIBuilder(this.clientConfigurationService.getIPVCoreStubURL())
-                        .setPath("/backend/generateInitialClaimsSet")
-                        .addParameter("cri", clientConfigurationService.getIpvCoreStubCriId())
-                        .addParameter("rowNumber", String.valueOf(userDataRowNumber))
-                        .addParameter("scoringPolicy", "gpg45")
-                        .addParameter("verificationScore", String.valueOf(verificationScore))
-                        .build();
+        parameters.forEach(uriBuilder::addParameter);
+
+        URI uri = uriBuilder.build();
         HttpRequest request = HttpRequest.newBuilder().uri(uri).GET().build();
+
         return sendHttpRequest(request).body();
     }
 


### PR DESCRIPTION
## Proposed changes

Refactored `getClaimsForUser` so there is only one place to add changes rather than two i.e a map of all parameters needed for method is added as part of the request in the new common step. Instead of added and common step and a new variant of `getClaimsForUser` in `IpvCoreStubClient` as previously done

[IpvCoreStubClient.java](https://github.com/govuk-one-login/ipv-cri-lib/compare/OJ-2813-add-userIdentity-with-context?expand=1#diff-1ade1c40794f3abbbe229e554c7527d8b0310b521c260354fbc79126a08f0ed0) is referenced by [CommonSteps.java](https://github.com/govuk-one-login/ipv-cri-lib/compare/OJ-2813-add-userIdentity-with-context?expand=1#diff-bdbd388801bc0170df4961794736e818ec8c4508fe4bf36fb6492cd254bd1aca) and not used elsewhere.

The common steps defined are used [here](https://github.com/search?q=org%3Agovuk-one-login%20stepdefinitions%2Cuk.gov.di.ipv.cri.common.library.stepdefinitions&type=code)

The new common step defined here is `user has the test-identity {int} and context of {string} in the form of a signed JWT string`
At the moment will be used for `/Addresses/v2` integration-test not written yet

- [OJ-2813](https://govukverify.atlassian.net/browse/OJ-2813)

[OJ-2813]: https://govukverify.atlassian.net/browse/OJ-2813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ