### PR TITLE
LIME-1312 Extract postcode from DrivingPermit fulladdress

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Credential Issuer common libraries Release Notes
 
+## 3.1.3
+
+    - Add support for extracting (best effort) a postcode from the full address field in driving permit shared claims.
+    - Update GoogleJavaFormat used by Spotless to 1.18.1
+    - Increase AWS SDK to 2.28.2
+    - Add missing SSM gradle configuration
+    - Correct static method DataStore.getClient() having a hidden DynamoDbEnhancedClient builder and not using the DynamoDbEnhancedClient provided by the clientProviderFactory
+    - Mark DataStore.getClient() as deprecated for removal as the approach leads to a client per datastore and prevents sharing a single DynamoDbEnhancedClient. 
+
 ## 3.1.2
     - Refactor getClaimsForUser to allow single parameter
     - Removed original getClaimsForUser, use new getClaimsForUser

--- a/build.gradle
+++ b/build.gradle
@@ -10,13 +10,13 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "3.1.2"
+def buildVersion = "3.1.3"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 
 ext {
 	dependencyVersions = [
-		aws_sdk_version          : "2.26.16",
+		aws_sdk_version          : "2.28.8",
 		aws_lambda_events_version: "3.11.6",
 		aws_powertools_version   : "1.18.0",
 		jackson_version          : "2.15.2", // Use AWS POM version only
@@ -86,6 +86,8 @@ dependencies {
 			"software.amazon.lambda:powertools-parameters:${dependencyVersions.aws_powertools_version}"
 
 	sqs "software.amazon.awssdk:sqs"
+
+	ssm "software.amazon.awssdk:ssm"
 
 	sso "software.amazon.awssdk:sso",
 			"software.amazon.awssdk:ssooidc"
@@ -177,7 +179,7 @@ sonar {
 spotless {
 	java {
 		target "**/src/**/*.java"
-		googleJavaFormat("1.13.0").aosp()
+		googleJavaFormat("1.18.1").aosp()
 		importOrder "", "javax", "java", "\\#"
 		endWithNewline()
 	}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/DataStore.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/DataStore.java
@@ -11,12 +11,9 @@ import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteResult;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.WriteBatch;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import uk.gov.di.ipv.cri.common.library.util.ClientProviderFactory;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,10 +34,17 @@ public class DataStore<T> {
         this.dynamoDbEnhancedClient = dynamoDbEnhancedClient;
     }
 
+    /**
+     * To be removed as, calling this will not allow sharing a single DynamoDbEnhancedClient.
+     *
+     * @deprecated
+     */
+    @SuppressWarnings("java:S1133")
+    @Deprecated(forRemoval = true)
     public static DynamoDbEnhancedClient getClient() {
-        DynamoDbClientBuilder clientBuilder = getDynamoDbClientBuilder(DynamoDbClient.builder());
+        ClientProviderFactory clientProviderFactory = new ClientProviderFactory();
 
-        return DynamoDbEnhancedClient.builder().dynamoDbClient(clientBuilder.build()).build();
+        return clientProviderFactory.getDynamoDbEnhancedClient();
     }
 
     public void create(T item) {
@@ -137,9 +141,5 @@ public class DataStore<T> {
     private BatchWriteResult persistBatch(WriteBatch writeBatch) {
         return this.dynamoDbEnhancedClient.batchWriteItem(
                 BatchWriteItemEnhancedRequest.builder().writeBatches(writeBatch).build());
-    }
-
-    private static DynamoDbClientBuilder getDynamoDbClientBuilder(DynamoDbClientBuilder builder) {
-        return builder.httpClient(UrlConnectionHttpClient.create()).region(Region.EU_WEST_2);
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/AccessTokenService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/AccessTokenService.java
@@ -149,7 +149,8 @@ public class AccessTokenService {
             AuthorizationCodeGrant authorizationGrant,
             ClientID clientID,
             SessionItem sessionItem)
-            throws AccessTokenValidationException, AccessTokenRequestException,
+            throws AccessTokenValidationException,
+                    AccessTokenRequestException,
                     SessionValidationException {
 
         AuthorizationCode authorizationCode = authorizationGrant.getAuthorizationCode();

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
@@ -149,7 +149,8 @@ public class SessionService {
     }
 
     public SessionItem getSessionByAuthorisationCode(String authCode)
-            throws SessionExpiredException, AuthorizationCodeExpiredException,
+            throws SessionExpiredException,
+                    AuthorizationCodeExpiredException,
                     SessionNotFoundException {
         SessionItem sessionItem;
 

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/AccessTokenServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/AccessTokenServiceTest.java
@@ -52,7 +52,8 @@ class AccessTokenServiceTest {
 
     @Test
     void shouldThrowExceptionForMissingJTI()
-            throws AccessTokenValidationException, SessionValidationException,
+            throws AccessTokenValidationException,
+                    SessionValidationException,
                     ClientConfigurationException {
 
         String jwtMissingJti =
@@ -298,7 +299,8 @@ class AccessTokenServiceTest {
 
     @Test
     void shouldValidateTokenRequestSuccessfully()
-            throws AccessTokenValidationException, SessionValidationException,
+            throws AccessTokenValidationException,
+                    SessionValidationException,
                     ClientConfigurationException {
 
         String authCodeValue = "12345";
@@ -343,7 +345,8 @@ class AccessTokenServiceTest {
 
     @Test
     void shouldThrowExceptionForMissingClientConfiguration()
-            throws AccessTokenValidationException, SessionValidationException,
+            throws AccessTokenValidationException,
+                    SessionValidationException,
                     ClientConfigurationException {
 
         String authCodeValue = "12345";

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
@@ -104,7 +104,8 @@ class SessionServiceTest {
 
     @Test
     void shouldGetSessionItemByAuthorizationCodeIndexSuccessfully()
-            throws AuthorizationCodeExpiredException, SessionExpiredException,
+            throws AuthorizationCodeExpiredException,
+                    SessionExpiredException,
                     SessionNotFoundException {
 
         String authCodeValue = UUID.randomUUID().toString();

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/KMSSignerTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/KMSSignerTest.java
@@ -64,7 +64,9 @@ class KMSSignerTest {
 
     @Test
     void shouldSignJWSHeaderSuccessfully()
-            throws JOSEException, NoSuchAlgorithmException, SignatureException,
+            throws JOSEException,
+                    NoSuchAlgorithmException,
+                    SignatureException,
                     InvalidKeyException {
         JWSHeader mockJWSHeader = mock(JWSHeader.class);
         byte[] payload = "test payload".getBytes();
@@ -93,7 +95,9 @@ class KMSSignerTest {
 
     @Test
     void shouldSignJWSObject()
-            throws JOSEException, NoSuchAlgorithmException, SignatureException,
+            throws JOSEException,
+                    NoSuchAlgorithmException,
+                    SignatureException,
                     InvalidKeyException {
         var signResponse = mock(SignResponse.class);
         when(mockKmsClient.sign(any(SignRequest.class))).thenReturn(signResponse);

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/SignedJWTFactoryTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/SignedJWTFactoryTest.java
@@ -34,7 +34,9 @@ class SignedJWTFactoryTest {
 
     @Test
     void shouldCreateASignedJwtSuccessfullyFromJWTClaimsSet()
-            throws JOSEException, InvalidKeySpecException, NoSuchAlgorithmException,
+            throws JOSEException,
+                    InvalidKeySpecException,
+                    NoSuchAlgorithmException,
                     ParseException {
         JWTClaimsSet testClaimsSet = new JWTClaimsSet.Builder().build();
         signedJwtFactory = new SignedJWTFactory(new ECDSASigner(getPrivateKey()));
@@ -46,7 +48,9 @@ class SignedJWTFactoryTest {
 
     @Test
     void shouldCreateASignedJwtSuccessfullyFromJWTClaimsSetString()
-            throws JOSEException, InvalidKeySpecException, NoSuchAlgorithmException,
+            throws JOSEException,
+                    InvalidKeySpecException,
+                    NoSuchAlgorithmException,
                     ParseException {
         signedJwtFactory = new SignedJWTFactory(new ECDSASigner(getPrivateKey()));
 
@@ -59,7 +63,9 @@ class SignedJWTFactoryTest {
 
     @Test
     void shouldCreateASignedJwtSuccessfullyFromJWTClaimsSetWhenKeyIDInHeader()
-            throws JOSEException, InvalidKeySpecException, NoSuchAlgorithmException,
+            throws JOSEException,
+                    InvalidKeySpecException,
+                    NoSuchAlgorithmException,
                     ParseException {
         JWTClaimsSet testClaimsSet = new JWTClaimsSet.Builder().build();
         signedJwtFactory = new SignedJWTFactory(new ECDSASigner(getPrivateKey()));


### PR DESCRIPTION
## Proposed changes

### What changed

	- Release 3.1.3

	- Extract DVLA postcode using a simple trim on the full address (mpv).
	- Extract DVA postcode using expected NI postcode prefix (mpv).
	- Remove Driving permit from existing test (address invalid to be sent with driving permit)
	- Add dedicated MapDrivingPermitSharedClaimsToPersonIdentityItem to handle postcode extraction tests.
	- - Adds test for known issue with mvp trim approach.
	- Update googleJavaFormat due to linting failures
	- Lint files with 1.18.1

	- Bump aws sdk version to 2.28.2
	- - Add missing ssm gradle configuration
	- Replace hidden DynamoDbClientBuilder builder in Datastore with one provided from the clientProviderFactor.
	- - DataStore.getClient() marked as deprecated, as this will lead to a unique client per Datastore and prevents the sharing of a single DynamoDbEnhancedClient.

### Why did it change

To allow extracting postcode from the full address.

DataStore.getClient() method deprecated now (missed in LIME-1071).

### Issue tracking

- [LIME-1312](https://govukverify.atlassian.net/browse/LIME-1312)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[LIME-1312]: https://govukverify.atlassian.net/browse/LIME-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ