### PR TITLE
OJ-2739: Update audit event tests to use test harness

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # Credential Issuer common libraries Release Notes
 
+## 3.3.0
+
+    - Updated audit event tests to use the new test harness events endpoint
+    - Added AWS credentials to sign the HTTP request for the events endpoint
+    - Added a Test Harness API client to interact with the test resources API
+    - Updated CriTestContext to expose test harness responses to the tests
+
 ## 3.2.1
 
     - Loosen Driving Permit Postcode extraction from DVA licenses
@@ -15,7 +22,7 @@
     - Increase AWS SDK to 2.28.2
     - Add missing SSM gradle configuration
     - Correct static method DataStore.getClient() having a hidden DynamoDbEnhancedClient builder and not using the DynamoDbEnhancedClient provided by the clientProviderFactory
-    - Mark DataStore.getClient() as deprecated for removal as the approach leads to a client per datastore and prevents sharing a single DynamoDbEnhancedClient. 
+    - Mark DataStore.getClient() as deprecated for removal as the approach leads to a client per datastore and prevents sharing a single DynamoDbEnhancedClient.
 
 ## 3.1.2
     - Refactor getClaimsForUser to allow single parameter

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ defaultTasks 'clean', 'spotlessApply', 'build'
 
 ext {
 	dependencyVersions = [
-		aws_sdk_version          : "2.28.8",
+		aws_sdk_version          : "2.29.1",
 		aws_lambda_events_version: "3.11.6",
 		aws_powertools_version   : "1.18.0",
 		jackson_version          : "2.15.2", // Use AWS POM version only

--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,7 @@ dependencies {
 
 	testFixturesApi configurations.aws
 	testFixturesApi configurations.sqs
+	testFixturesApi configurations.aws_crt_client
 	testFixturesApi configurations.cloudformation
 	testFixturesApi	configurations.cucumber
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "3.2.1"
+def buildVersion = "3.3.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,8 @@ dependencies {
 			"com.fasterxml.jackson.core:jackson-databind",
 			"com.fasterxml.jackson.core:jackson-annotations",
 			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${dependencyVersions.jackson_version}"
+			"com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${dependencyVersions.jackson_version}",
+			"com.github.erosb:everit-json-schema:1.14.4"
 
 	powertools "software.amazon.lambda:powertools-logging:${dependencyVersions.aws_powertools_version}",
 			"software.amazon.lambda:powertools-metrics:${dependencyVersions.aws_powertools_version}"
@@ -123,7 +124,6 @@ dependencies {
 }
 
 dependencies {
-
 	implementation configurations.aws,
 			configurations.lambda,
 			configurations.jackson,

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEvent.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEvent.java
@@ -20,7 +20,9 @@ public class AuditEvent<T> {
     @JsonProperty("component_id")
     private final String issuer;
 
+    @JsonProperty("restricted")
     private PersonIdentityDetailed restricted;
+
     private AuditEventUser user;
     private T extensions;
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/DeviceInformation.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/DeviceInformation.java
@@ -1,9 +1,11 @@
 package uk.gov.di.ipv.cri.common.library.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DeviceInformation {
     @JsonProperty(value = "encoded")
     private String encoded;

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/PersonIdentityDetailed.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/PersonIdentityDetailed.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.cri.common.library.domain.personidentity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -72,14 +73,16 @@ public class PersonIdentityDetailed {
      * @see uk.gov.di.ipv.cri.common.library.service.PersonIdentityDetailedFactory
      *     createPersonIdentityDetailedWith
      */
+    @JsonCreator
     @Deprecated(since = "1.5.0")
     public PersonIdentityDetailed(
-            List<Name> names,
-            List<BirthDate> birthDates,
-            List<Address> addresses,
-            List<DrivingPermit> drivingPermits,
-            List<Passport> passports,
-            List<SocialSecurityRecord> socialSecurityRecords) {
+            @JsonProperty("name") List<Name> names,
+            @JsonProperty("birthDate") List<BirthDate> birthDates,
+            @JsonProperty("address") List<Address> addresses,
+            @JsonProperty("drivingPermit") List<DrivingPermit> drivingPermits,
+            @JsonProperty("passport") List<Passport> passports,
+            @JsonProperty("socialSecurityRecord")
+                    List<SocialSecurityRecord> socialSecurityRecords) {
         this.names = names;
         this.birthDates = birthDates;
         this.addresses = addresses;

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/JsonSchemaValidator.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/JsonSchemaValidator.java
@@ -1,0 +1,35 @@
+package uk.gov.di.ipv.cri.common.library.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.everit.json.schema.Schema;
+import org.everit.json.schema.ValidationException;
+import org.everit.json.schema.loader.SchemaLoader;
+import org.json.JSONObject;
+
+public class JsonSchemaValidator {
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private JsonSchemaValidator() {}
+
+    public static boolean validateJsonAgainstSchema(String json, String jsonSchema)
+            throws JsonProcessingException {
+        final JsonNode jsonNode = OBJECT_MAPPER.readTree(json);
+        final JsonNode jsonSchemaNode = OBJECT_MAPPER.readTree(jsonSchema);
+        final JSONObject jsonSchemaObject = new JSONObject(jsonSchemaNode.toString());
+        final Schema schema = SchemaLoader.load(jsonSchemaObject);
+
+        try {
+            schema.validate(new JSONObject(jsonNode.toString()));
+        } catch (ValidationException e) {
+            LOGGER.error("Failed to validate JSON against JSON schema", e);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/RawAuditEventTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/RawAuditEventTest.java
@@ -1,0 +1,28 @@
+package uk.gov.di.ipv.cri.common.library.domain.personidentity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.cri.common.library.domain.RawAuditEvent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RawAuditEventTest {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    void testRawEventDataIsSetWithTestProperties() throws JsonProcessingException {
+        final String json = "{\"S\":\"sampleData\", \"test\":\"test\"}";
+        final RawAuditEvent rawAuditEvent = OBJECT_MAPPER.readValue(json, RawAuditEvent.class);
+
+        assertEquals("sampleData", rawAuditEvent.getData());
+    }
+
+    @Test
+    void rawEventDataIsReturnedWhenSet() {
+        final RawAuditEvent rawAuditEvent = new RawAuditEvent();
+        rawAuditEvent.setData("newData");
+
+        assertEquals("newData", rawAuditEvent.getData());
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/TestHarnessResponseTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/TestHarnessResponseTest.java
@@ -1,0 +1,79 @@
+package uk.gov.di.ipv.cri.common.library.domain.personidentity;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.domain.AuditEvent;
+import uk.gov.di.ipv.cri.common.library.domain.RawAuditEvent;
+import uk.gov.di.ipv.cri.common.library.domain.TestHarnessResponse;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TestHarnessResponseTest {
+    @Mock private RawAuditEvent mockRawAuditEvent;
+
+    @Test
+    void testConstructorAndGetter() {
+        final var response =
+                new TestHarnessResponse<AuditEvent<Map<String, Object>>>(mockRawAuditEvent);
+
+        assertEquals(
+                mockRawAuditEvent,
+                response.getEvent(),
+                "Constructor should correctly set rawEvent");
+    }
+
+    @Test
+    void testDefaultConstructorAndSetter() {
+        final var response = new TestHarnessResponse<AuditEvent<Map<String, Object>>>();
+        response.setEvent(mockRawAuditEvent);
+
+        assertEquals(
+                mockRawAuditEvent, response.getEvent(), "Setter should correctly set rawEvent");
+    }
+
+    @Test
+    void sendValidDataToReadAuditEventsCorrectly() throws IOException {
+        final var response =
+                new TestHarnessResponse<AuditEvent<Map<String, Object>>>(mockRawAuditEvent);
+
+        final String jsonData =
+                "{\"timestamp\": \"1730463762\", \"event_timestamp_ms\": \"1730463762900\", \"event_name\": \"IPV_ADDRESS_CRI_START\", \"component_id\": \"https://review-a.dev.account.gov.uk\"}";
+
+        when(mockRawAuditEvent.getData()).thenReturn(jsonData);
+        AuditEvent<AuditEvent<Map<String, Object>>> auditEvent = response.readAuditEvent();
+
+        assertNotNull(auditEvent, "readAuditEvent should return a non-null AuditEvent object");
+    }
+
+    @Test
+    void sendInvalidDataToReadAuditEventThrowIOException() {
+        final var response =
+                new TestHarnessResponse<AuditEvent<Map<String, Object>>>(mockRawAuditEvent);
+
+        when(mockRawAuditEvent.getData()).thenReturn("{ invalid json }");
+
+        assertThrows(
+                IOException.class,
+                response::readAuditEvent,
+                "Invalid JSON should throw IOException");
+    }
+
+    @Test
+    void sendNoRawEventToReadAuditEventThrowNullPointerException() {
+        final var response = new TestHarnessResponse<AuditEvent<Map<String, Object>>>();
+
+        assertThrows(
+                NullPointerException.class,
+                response::readAuditEvent,
+                "No rawEvent should throw NullPointerException");
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/JsonSchemaValidatorTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/JsonSchemaValidatorTest.java
@@ -1,0 +1,74 @@
+package uk.gov.di.ipv.cri.common.library.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JsonSchemaValidatorTest {
+    private static final String VALID_JSON = "{ \"name\": \"John\", \"age\": 30 }";
+    private static final String INVALID_JSON = "{ \"name\": \"John\", \"age\": \"thirty\" }";
+
+    private static final String VALID_SCHEMA =
+            "{\n"
+                    + "  \"type\": \"object\",\n"
+                    + "  \"properties\": {\n"
+                    + "    \"name\": { \"type\": \"string\" },\n"
+                    + "    \"age\": { \"type\": \"integer\" }\n"
+                    + "  },\n"
+                    + "  \"required\": [\"name\", \"age\"]\n"
+                    + "}";
+
+    private static final String INVALID_SCHEMA =
+            "{ \"type\": \"object\", \"properties\": { \"name\": { \"type\": \"unknownType\" } } }";
+
+    @Test
+    void validateAgainstSchemaWithValidJsonAndSchemaReturnTrue() throws JsonProcessingException {
+        final boolean result =
+                JsonSchemaValidator.validateJsonAgainstSchema(VALID_JSON, VALID_SCHEMA);
+
+        assertTrue(result, "Expected valid JSON to pass validation against the schema");
+    }
+
+    @Test
+    void validateAgainstSchemaWithInvalidJsonReturnFalse() throws JsonProcessingException {
+        final boolean result =
+                JsonSchemaValidator.validateJsonAgainstSchema(INVALID_JSON, VALID_SCHEMA);
+
+        assertFalse(result, "Expected invalid JSON to fail validation against the schema");
+    }
+
+    @Test
+    void validateAgainstSchemaMissingRequiredFieldReturnFalse() throws JsonProcessingException {
+        final String jsonWithMissingField = "{ \"name\": \"John\" }"; // Missing "age" field
+
+        final boolean result =
+                JsonSchemaValidator.validateJsonAgainstSchema(jsonWithMissingField, VALID_SCHEMA);
+
+        assertFalse(result, "Expected JSON missing required fields to fail validation");
+    }
+
+    @Test
+    void validateAgainstSchemaWithIncorrectJsonThrowsJsonProcessingException() {
+        final String incorrectJson = "{ \"name\": \"John\", \"age\": 30 ";
+
+        assertThrows(
+                JsonProcessingException.class,
+                () -> {
+                    JsonSchemaValidator.validateJsonAgainstSchema(incorrectJson, VALID_SCHEMA);
+                },
+                "Expected incorrect JSON to throw JsonProcessingException");
+    }
+
+    @Test
+    void validateAgainstSchemaWithInvalidSchemaThrowsValidationException() {
+        assertThrows(
+                Exception.class,
+                () -> {
+                    JsonSchemaValidator.validateJsonAgainstSchema(VALID_JSON, INVALID_SCHEMA);
+                },
+                "Expected invalid schema to throw an exception during validation");
+    }
+}

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/ClientConfigurationService.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/ClientConfigurationService.java
@@ -15,6 +15,7 @@ public class ClientConfigurationService {
     private final String ipvCoreStubPassword;
     private final String ipvCoreStubCriId;
     private final String ipvCoreStubClientId;
+    private final String testResourcesStackName;
 
     public ClientConfigurationService() {
         this.environment =
@@ -58,6 +59,9 @@ public class ClientConfigurationService {
                                 MISSING_ENV_VARIABLE_ERROR_MSG_FORMAT, "IPV_CORE_STUB_CRI_ID"));
         this.ipvCoreStubClientId =
                 Optional.ofNullable(System.getenv("DEFAULT_CLIENT_ID")).orElse("ipv-core-stub");
+        this.testResourcesStackName =
+                Optional.ofNullable(System.getenv("TEST_RESOURCES_STACK_NAME"))
+                        .orElse("test-resources");
     }
 
     public String getPrivateApiEndpoint() {
@@ -70,6 +74,10 @@ public class ClientConfigurationService {
 
     public String getPublicApiKey() {
         return this.publicApiKey;
+    }
+
+    public String getTestResourcesStackName() {
+        return this.testResourcesStackName;
     }
 
     public String getIPVCoreStubURL() {

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/CommonApiClient.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/CommonApiClient.java
@@ -8,16 +8,15 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
 public class CommonApiClient {
-
     private final HttpClient httpClient;
     private final ClientConfigurationService clientConfigurationService;
+
+    private static final String JSON_MIME_MEDIA_TYPE = "application/json";
 
     public CommonApiClient(ClientConfigurationService clientConfigurationService) {
         this.clientConfigurationService = clientConfigurationService;
         this.httpClient = HttpClient.newBuilder().build();
     }
-
-    private static final String JSON_MIME_MEDIA_TYPE = "application/json";
 
     public HttpResponse<String> sendAuthorizationRequest(String sessionId)
             throws IOException, InterruptedException {

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/TestResourcesClient.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/TestResourcesClient.java
@@ -1,0 +1,93 @@
+package uk.gov.di.ipv.cri.common.library.client;
+
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
+import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.utils.IoUtils;
+import uk.gov.di.ipv.cri.common.library.aws.CloudFormationHelper;
+import uk.gov.di.ipv.cri.common.library.util.URIBuilder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+public class TestResourcesClient {
+    private final String testHarnessUrl;
+
+    private static final SdkHttpClient CLIENT = AwsCrtHttpClient.builder().build();
+    private static final AwsV4HttpSigner SIGNER = AwsV4HttpSigner.create();
+
+    public TestResourcesClient(ClientConfigurationService clientConfigurationService) {
+        this.testHarnessUrl =
+                CloudFormationHelper.getOutput(
+                        clientConfigurationService.getTestResourcesStackName(),
+                        "TestHarnessExecuteUrl");
+    }
+
+    /** Convert the response body to a string and close its input stream */
+    public static String getResponseBody(HttpExecuteResponse response) throws IOException {
+        if (response.responseBody().isEmpty()) {
+            return null;
+        }
+
+        try (InputStream bodyStream = response.responseBody().get()) {
+            return IoUtils.toUtf8String(bodyStream);
+        }
+    }
+
+    public HttpExecuteResponse sendEventRequest(String sessionId) throws IOException {
+        final URI eventsEndpointURI =
+                new URIBuilder(this.testHarnessUrl)
+                        .setPath("events")
+                        .addParameter(
+                                "partitionKey",
+                                URLEncoder.encode(
+                                        String.format("%s%s", "SESSION#", sessionId),
+                                        StandardCharsets.UTF_8))
+                        .addParameter("sortKey", "TXMA")
+                        .build();
+
+        final SdkHttpFullRequest request =
+                SdkHttpFullRequest.builder()
+                        .method(SdkHttpMethod.GET)
+                        .uri(eventsEndpointURI)
+                        .build();
+
+        return sendRequest(request);
+    }
+
+    private HttpExecuteResponse sendRequest(SdkHttpFullRequest unsignedRequest) throws IOException {
+        final SignedRequest signedRequest = signRequest(unsignedRequest);
+
+        final HttpExecuteRequest httpExecuteRequest =
+                HttpExecuteRequest.builder()
+                        .request(signedRequest.request())
+                        .contentStreamProvider(signedRequest.payload().orElse(null))
+                        .build();
+
+        return CLIENT.prepareRequest(httpExecuteRequest).call();
+    }
+
+    private SignedRequest signRequest(SdkHttpFullRequest unsignedRequest) {
+        try (DefaultCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create()) {
+            return SIGNER.sign(
+                    signRequest ->
+                            signRequest
+                                    .request(unsignedRequest)
+                                    .identity(credentialsProvider.resolveCredentials())
+                                    .putProperty(
+                                            AwsV4HttpSigner.SERVICE_SIGNING_NAME, "execute-api")
+                                    .putProperty(
+                                            AwsV4HttpSigner.REGION_NAME, Region.EU_WEST_2.id()));
+        }
+    }
+}

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/TestResourcesClient.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/TestResourcesClient.java
@@ -33,7 +33,6 @@ public class TestResourcesClient {
                         "TestHarnessExecuteUrl");
     }
 
-    /** Convert the response body to a string and close its input stream */
     public static String getResponseBody(HttpExecuteResponse response) throws IOException {
         if (response.responseBody().isEmpty()) {
             return null;

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/domain/RawAuditEvent.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/domain/RawAuditEvent.java
@@ -1,0 +1,24 @@
+package uk.gov.di.ipv.cri.common.library.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RawAuditEvent {
+    @JsonProperty("S")
+    private String data;
+
+    public RawAuditEvent(String data) {
+        this.data = data;
+    }
+
+    public RawAuditEvent() {}
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String s) {
+        this.data = s;
+    }
+}

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/domain/TestHarnessResponse.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/domain/TestHarnessResponse.java
@@ -1,0 +1,34 @@
+package uk.gov.di.ipv.cri.common.library.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TestHarnessResponse<T> {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @JsonProperty("event")
+    private RawAuditEvent rawAuditEvent;
+
+    public TestHarnessResponse(RawAuditEvent rawAuditEvent) {
+        this.rawAuditEvent = rawAuditEvent;
+    }
+
+    public TestHarnessResponse() {}
+
+    public RawAuditEvent getEvent() {
+        return rawAuditEvent;
+    }
+
+    public AuditEvent<T> readAuditEvent() throws IOException {
+        return OBJECT_MAPPER.readValue(rawAuditEvent.getData(), new TypeReference<>() {});
+    }
+
+    public void setEvent(RawAuditEvent rawAuditEvent) {
+        this.rawAuditEvent = rawAuditEvent;
+    }
+}

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CommonSteps.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CommonSteps.java
@@ -10,6 +10,7 @@ import io.cucumber.java.en.When;
 import uk.gov.di.ipv.cri.common.library.client.ClientConfigurationService;
 import uk.gov.di.ipv.cri.common.library.client.CommonApiClient;
 import uk.gov.di.ipv.cri.common.library.client.IpvCoreStubClient;
+import uk.gov.di.ipv.cri.common.library.client.TestResourcesClient;
 
 import java.io.IOException;
 import java.util.Map;
@@ -21,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class CommonSteps {
     private final ObjectMapper objectMapper;
     private final CommonApiClient commonApiClient;
+    private final TestResourcesClient testResourcesClient;
 
     private final IpvCoreStubClient ipvCoreStubClient;
     private final CriTestContext testContext;
@@ -33,6 +35,7 @@ public class CommonSteps {
             ClientConfigurationService clientConfigurationService, CriTestContext testContext) {
         this.clientConfigurationService = clientConfigurationService;
         this.commonApiClient = new CommonApiClient(clientConfigurationService);
+        this.testResourcesClient = new TestResourcesClient(clientConfigurationService);
         this.ipvCoreStubClient = new IpvCoreStubClient(clientConfigurationService);
         this.objectMapper = new ObjectMapper();
         this.testContext = testContext;
@@ -121,6 +124,12 @@ public class CommonSteps {
                 this.ipvCoreStubClient.getPrivateKeyJWTFormParamsForAuthCode(
                         authorizationCode.trim());
         this.testContext.setResponse(this.commonApiClient.sendTokenRequest(privateKeyJWT));
+    }
+
+    @When("user sends a GET request to events end point")
+    public void userSendsAGetRequestToEventsEndpoint() throws IOException {
+        this.testContext.setResponse(
+                this.testResourcesClient.sendEventRequest(this.testContext.getSessionId()));
     }
 
     @Then("user gets a session-id")

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CriTestContext.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CriTestContext.java
@@ -1,19 +1,38 @@
 package uk.gov.di.ipv.cri.common.library.stepdefinitions;
 
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import uk.gov.di.ipv.cri.common.library.client.TestResourcesClient;
+
+import java.io.IOException;
 import java.net.http.HttpResponse;
 
 public class CriTestContext {
+    private HttpExecuteResponse testHarnessResponse;
     private HttpResponse<String> response;
     private String sessionId;
     private String accessToken;
     private String serialisedUserIdentity;
+    private String testHarnessResponseBody;
 
     public HttpResponse<String> getResponse() {
         return response;
     }
 
+    public HttpExecuteResponse getTestHarnessResponse() {
+        return testHarnessResponse;
+    }
+
+    public String getTestHarnessResponseBody() {
+        return testHarnessResponseBody;
+    }
+
     public void setResponse(HttpResponse<String> response) {
         this.response = response;
+    }
+
+    public void setResponse(HttpExecuteResponse response) throws IOException {
+        this.testHarnessResponse = response;
+        this.testHarnessResponseBody = TestResourcesClient.getResponseBody(response);
     }
 
     public String getSessionId() {


### PR DESCRIPTION
## Proposed changes

### What changed

- Updated audit event tests to use the new test harness events endpoint
- Added AWS credentials to sign the HTTP request for the events endpoint 
- Removed the previous SQS and cloudformation usages for TxMA step definitions in Address repo

Tested the changes in using publishToMavenLocal() command and tests are all passing:
![image](https://github.com/user-attachments/assets/6e279444-b565-4d4d-8824-e3f2e8b4cf48)


### Why did it change
To use the test harness to assert that TxMA events are written by CRIs in a common way. To support the testing of the cloudfront headers, this solution is being used in other parts of the programme. 

### Issue tracking
- [OJ-2739](https://govukverify.atlassian.net/browse/OJ-2739)

## Checklists

### Environment variables or secrets

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2739]: https://govukverify.atlassian.net/browse/OJ-2739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ