### PR TITLE
OJ-2816: Add addressRegion to CanonicalAddress

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Credential Issuer common libraries Release Notes
 
+## 3.2.0
+    - Adds addressRegion to CanonicalAddress
+
 ## 3.1.3
 
     - Add support for extracting (best effort) a postcode from the full address field in driving permit shared claims.

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "3.1.3"
+def buildVersion = "3.2.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/CanonicalAddress.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/CanonicalAddress.java
@@ -17,22 +17,15 @@ public class CanonicalAddress {
     private String subBuildingName;
     private String buildingNumber;
     private String buildingName;
-
     private String dependentThoroughfare;
-
     private String dependentStreetName;
-
     private String streetName;
-
     private String doubleDependentAddressLocality;
-
     private String dependentAddressLocality;
-
     private String addressLocality;
-
     private String postalCode;
-
     private String addressCountry;
+    private String addressRegion;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private Date validFrom;
@@ -146,6 +139,14 @@ public class CanonicalAddress {
 
     public void setAddressCountry(String addressCountry) {
         this.addressCountry = addressCountry;
+    }
+
+    public String getAddressRegion() {
+        return addressRegion;
+    }
+
+    public void setAddressRegion(String addressRegion) {
+        this.addressRegion = addressRegion;
     }
 
     public LocalDate getValidFrom() {


### PR DESCRIPTION
## Proposed changes

### What changed

Add addressRegion to CanonicalAddress

### Why did it change

New field for OneLogin address schema to support International Addresses