### PR TITLE
LIME-1312 Loosen Driving Permit Postcode extraction from DVA licenses

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,11 @@
 # Credential Issuer common libraries Release Notes
 
+## 3.2.1
+
+    - Loosen Driving Permit Postcode extraction from DVA licenses
+
 ## 3.2.0
+
     - Adds addressRegion to CanonicalAddress
 
 ## 3.1.3

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "3.2.0"
+def buildVersion = "3.2.1"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapper.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapper.java
@@ -3,7 +3,6 @@ package uk.gov.di.ipv.cri.common.library.service;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.BirthDate;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.DrivingPermit;
-import uk.gov.di.ipv.cri.common.library.domain.personidentity.DrivingPermitIssuer;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Name;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.NamePart;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
@@ -400,11 +399,7 @@ public class PersonIdentityMapper {
                                 CanonicalAddress canonicalAddress = new CanonicalAddress();
 
                                 canonicalAddress.setPostalCode(
-                                        DrivingPermitIssuer.DVA.equalsIgnoreCase(dp.getIssuedBy())
-                                                ? extractPostalCodeFromDVADrivingPermitFullAddress(
-                                                        dp)
-                                                : extractPostalCodeFromDVLADrivingPermitFullAddress(
-                                                        dp));
+                                        extractPostalCodeFromDrivingPermitFullAddress(dp));
 
                                 return canonicalAddress;
                             }
@@ -416,39 +411,7 @@ public class PersonIdentityMapper {
                 .collect(Collectors.toList());
     }
 
-    private String extractPostalCodeFromDVADrivingPermitFullAddress(DrivingPermit dp) {
-
-        if (!DrivingPermitIssuer.DVA.equalsIgnoreCase(dp.getIssuedBy())) {
-            return null;
-        }
-
-        String postalCode = null;
-
-        String fullAddress = dp.getFullAddress().toUpperCase();
-        int len = fullAddress.length();
-
-        int pos = fullAddress.lastIndexOf("BT");
-        String possiblePostcode = pos >= 0 ? fullAddress.substring(pos, len) : "";
-
-        if (possiblePostcode.length() >= 6) {
-            // Remove Leading/Trailing Padding but not any separator space
-            possiblePostcode =
-                    possiblePostcode.startsWith(",")
-                            ? possiblePostcode.substring(1)
-                            : possiblePostcode;
-            possiblePostcode = possiblePostcode.stripLeading();
-            possiblePostcode = possiblePostcode.stripTrailing();
-            postalCode = possiblePostcode;
-        }
-
-        return postalCode;
-    }
-
-    private String extractPostalCodeFromDVLADrivingPermitFullAddress(DrivingPermit dp) {
-
-        if (!DrivingPermitIssuer.DVLA.equalsIgnoreCase(dp.getIssuedBy())) {
-            return null;
-        }
+    private String extractPostalCodeFromDrivingPermitFullAddress(DrivingPermit dp) {
 
         String postalCode = null;
 

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapperTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapperTest.java
@@ -252,7 +252,7 @@ class PersonIdentityMapperTest {
         "DVA, ',BT11 1AB', BT11 1AB", // 8 Exactly, with leading comma
         // Full Address
         "DVA, 'Building, Road, Town, County, BT11AB', BT11AB", // 6Char postcode/ address-commas
-        "DVA, 'Building Road Town County BT11AB',BT11AB", // 6Char postcode/ address-spaces
+        "DVA, 'Building Road Town County BT11AB',Y BT11AB", // 6Char postcode/ address-spaces
         "DVA, 'Building, Road, Town, County, BT1 1AB', BT1 1AB", // 7Char postcode/ address-commas
         "DVA, 'Building Road Town County BT1 1AB',BT1 1AB", // 7Char postcode address-spaces
         "DVA, 'Building, Road, Town, County, BT121AB', BT121AB", // 7Char postcode address-commas
@@ -260,8 +260,8 @@ class PersonIdentityMapperTest {
         "DVA, 'Building, Road, Town, County, BT12 1AB', BT12 1AB", // 8Char postcode/ Address commas
         "DVA, 'Building Road Town County BT12 1AB',BT12 1AB", // 8Char postcode, address-spaces
         // DVA No postcode Tests
-        "DVA, 'Building, Road, Town, County,',", // No postcode / Address commas
-        "DVA, 'Building Road Town County', ", // No postcode/ Address spaces
+        "DVA, 'Building, Road, Town, County', COUNTY", // No postcode / Address commas
+        "DVA, 'Building Road Town County', N COUNTY", // No postcode/ Address spaces
         // DVLA
         "DVLA,,", // No full address
         // Just postcodes


### PR DESCRIPTION
## Proposed changes

### What changed

Loosen Driving Permit Postcode extraction from DVA licenses

### Why did it change

Extraction was preventing test data being used

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1312](https://govukverify.atlassian.net/browse/LIME-1312)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[LIME-1312]: https://govukverify.atlassian.net/browse/LIME-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ