### PR TITLE
OJ-2816: Add addressRegion to Address

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## 3.4.0
 
     - Adds addressRegion to Address
+    - Excludes Address.java from Sonar duplication checks as it is very similar to CanonicalAddress.java
 
 ## 3.3.0
 
@@ -26,7 +27,7 @@
     - Increase AWS SDK to 2.28.2
     - Add missing SSM gradle configuration
     - Correct static method DataStore.getClient() having a hidden DynamoDbEnhancedClient builder and not using the DynamoDbEnhancedClient provided by the clientProviderFactory
-    - Mark DataStore.getClient() as deprecated for removal as the approach leads to a client per datastore and prevents sharing a single DynamoDbEnhancedClient. 
+    - Mark DataStore.getClient() as deprecated for removal as the approach leads to a client per datastore and prevents sharing a single DynamoDbEnhancedClient.
 
 ## 3.1.2
     - Refactor getClaimsForUser to allow single parameter

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 3.4.0
+
+    - Adds addressRegion to Address
+
 ## 3.3.0
 
     - Updated audit event tests to use the new test harness events endpoint
@@ -22,7 +26,7 @@
     - Increase AWS SDK to 2.28.2
     - Add missing SSM gradle configuration
     - Correct static method DataStore.getClient() having a hidden DynamoDbEnhancedClient builder and not using the DynamoDbEnhancedClient provided by the clientProviderFactory
-    - Mark DataStore.getClient() as deprecated for removal as the approach leads to a client per datastore and prevents sharing a single DynamoDbEnhancedClient.
+    - Mark DataStore.getClient() as deprecated for removal as the approach leads to a client per datastore and prevents sharing a single DynamoDbEnhancedClient. 
 
 ## 3.1.2
     - Refactor getClaimsForUser to allow single parameter

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "3.3.0"
+def buildVersion = "3.4.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/build.gradle
+++ b/build.gradle
@@ -174,6 +174,7 @@ sonar {
 		property "sonar.projectKey", "ipv-cri-lib"
 		property "sonar.organization", "govuk-one-login"
 		property "sonar.host.url", "https://sonarcloud.io"
+		property "sonar.cpd.exclusions", "**/di/ipv/cri/common/library/domain/personidentity/Address.java"
 	}
 }
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/Address.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/Address.java
@@ -25,6 +25,7 @@ public class Address {
     private String addressLocality;
     private String postalCode;
     private String addressCountry;
+    private String addressRegion;
 
     public Address() {
         this(new CanonicalAddress());
@@ -44,6 +45,7 @@ public class Address {
         this.addressLocality = address.getAddressLocality();
         this.postalCode = address.getPostalCode();
         this.addressCountry = address.getAddressCountry();
+        this.addressRegion = address.getAddressRegion();
         this.validFrom = address.getValidFrom();
         this.validUntil = address.getValidUntil();
     }
@@ -156,6 +158,14 @@ public class Address {
 
     public void setAddressCountry(String addressCountry) {
         this.addressCountry = addressCountry;
+    }
+
+    public String getAddressRegion() {
+        return addressRegion;
+    }
+
+    public void setAddressRegion(String addressRegion) {
+        this.addressRegion = addressRegion;
     }
 
     public LocalDate getValidFrom() {

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapper.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapper.java
@@ -339,6 +339,7 @@ public class PersonIdentityMapper {
                             canonicalAddress.setDependentStreetName(a.getDependentStreetName());
                             canonicalAddress.setStreetName(a.getStreetName());
                             canonicalAddress.setAddressCountry(a.getAddressCountry());
+                            canonicalAddress.setAddressRegion(a.getAddressRegion());
                             canonicalAddress.setPostalCode(a.getPostalCode());
                             if (Objects.nonNull(a.getValidFrom())) {
                                 canonicalAddress.setValidFrom(a.getValidFrom());

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapperTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapperTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.cri.common.library.service;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -362,105 +363,138 @@ class PersonIdentityMapperTest {
         assertEquals(drivingPermit.getFullAddress(), mappedDrivingPermit.getFullAddress());
     }
 
-    @Test
-    void shouldMapPersonIdentityItemToPersonIdentityDetailed() {
-        PersonIdentityNamePart firstNamePart = new PersonIdentityNamePart();
-        firstNamePart.setType("GivenName");
-        firstNamePart.setValue("Jon");
-        PersonIdentityNamePart surnamePart = new PersonIdentityNamePart();
-        surnamePart.setType("FamilyName");
-        surnamePart.setValue("Smith");
-        PersonIdentityName name = new PersonIdentityName();
-        name.setNameParts(List.of(firstNamePart, surnamePart));
+    @Nested
+    class MapPersonIdentityItemToPersonIdentityDetailed {
 
-        PersonIdentityDateOfBirth birthDate = new PersonIdentityDateOfBirth();
-        birthDate.setValue(LocalDate.of(1980, 10, 20));
+        private final PersonIdentityNamePart firstNamePart = new PersonIdentityNamePart();
+        private final PersonIdentityNamePart surnamePart = new PersonIdentityNamePart();
+        private final PersonIdentityDateOfBirth birthDate = new PersonIdentityDateOfBirth();
+        private final CanonicalAddress address = new CanonicalAddress();
+        private final PersonIdentityDrivingPermit personIdentityDrivingPermit =
+                new PersonIdentityDrivingPermit();
 
-        CanonicalAddress address = new CanonicalAddress();
-        address.setAddressCountry("GB");
-        address.setAddressRegion("dummyRegion");
-        address.setAddressLocality("locality");
-        address.setBuildingNumber("buildingNum");
-        address.setBuildingName("buildingName");
-        address.setDepartmentName("deptName");
-        address.setDependentAddressLocality("depAddressLocality");
-        address.setDependentStreetName("depStreetName");
-        address.setDoubleDependentAddressLocality("doubleDepAddressLocality");
-        address.setOrganisationName("orgName");
-        address.setPostalCode("postcode");
-        address.setStreetName("street");
-        address.setSubBuildingName("subBuildingName");
-        address.setUprn(2394501657L);
-        address.setValidFrom(LocalDate.of(2011, 10, 21));
-        address.setValidUntil(LocalDate.of(2017, 11, 25));
+        private PersonIdentityDetailed mappedPersonIdentity;
 
-        PersonIdentitySocialSecurityRecord personIdentitySocialSecurityRecord =
-                new PersonIdentitySocialSecurityRecord();
-        personIdentitySocialSecurityRecord.setPersonalNumber("AA000003D");
+        @BeforeEach
+        void setup() {
+            firstNamePart.setType("GivenName");
+            firstNamePart.setValue("Jon");
+            surnamePart.setType("FamilyName");
+            surnamePart.setValue("Smith");
+            PersonIdentityName name = new PersonIdentityName();
+            name.setNameParts(List.of(firstNamePart, surnamePart));
 
-        PersonIdentityDrivingPermit personIdentityDrivingPermit = new PersonIdentityDrivingPermit();
-        personIdentityDrivingPermit.setPersonalNumber("personalNumber");
-        personIdentityDrivingPermit.setExpiryDate(LocalDate.of(2029, 10, 21).toString());
-        personIdentityDrivingPermit.setIssueDate(LocalDate.of(2011, 10, 21).toString());
-        personIdentityDrivingPermit.setIssueNumber("issueNumber");
-        personIdentityDrivingPermit.setIssuedBy("issuedBy");
-        personIdentityDrivingPermit.setFullAddress("fullAddress");
+            birthDate.setValue(LocalDate.of(1980, 10, 20));
 
-        PersonIdentityItem testPersonIdentityItem = new PersonIdentityItem();
-        testPersonIdentityItem.setNames(List.of(name));
-        testPersonIdentityItem.setBirthDates(List.of(birthDate));
-        testPersonIdentityItem.setAddresses(List.of(address));
-        testPersonIdentityItem.setSocialSecurityRecords(
-                List.of(personIdentitySocialSecurityRecord));
-        testPersonIdentityItem.setDrivingPermits(List.of(personIdentityDrivingPermit));
+            address.setAddressCountry("GB");
+            address.setAddressRegion("dummyRegion");
+            address.setAddressLocality("locality");
+            address.setBuildingNumber("buildingNum");
+            address.setBuildingName("buildingName");
+            address.setDepartmentName("deptName");
+            address.setDependentAddressLocality("depAddressLocality");
+            address.setDependentStreetName("depStreetName");
+            address.setDoubleDependentAddressLocality("doubleDepAddressLocality");
+            address.setOrganisationName("orgName");
+            address.setPostalCode("postcode");
+            address.setStreetName("street");
+            address.setSubBuildingName("subBuildingName");
+            address.setUprn(2394501657L);
+            address.setValidFrom(LocalDate.of(2011, 10, 21));
+            address.setValidUntil(LocalDate.of(2017, 11, 25));
 
-        PersonIdentityDetailed mappedPersonIdentity =
-                personIdentityMapper.mapToPersonIdentityDetailed(testPersonIdentityItem);
+            PersonIdentitySocialSecurityRecord personIdentitySocialSecurityRecord =
+                    new PersonIdentitySocialSecurityRecord();
+            personIdentitySocialSecurityRecord.setPersonalNumber("AA000003D");
 
-        List<NamePart> mappedNameParts = mappedPersonIdentity.getNames().get(0).getNameParts();
-        assertEquals(firstNamePart.getValue(), mappedNameParts.get(0).getValue());
-        assertEquals(firstNamePart.getType(), mappedNameParts.get(0).getType());
-        assertEquals(surnamePart.getValue(), mappedNameParts.get(1).getValue());
-        assertEquals(surnamePart.getType(), mappedNameParts.get(1).getType());
-        assertEquals(birthDate.getValue(), mappedPersonIdentity.getBirthDates().get(0).getValue());
-        Address mappedAddress = mappedPersonIdentity.getAddresses().get(0);
-        assertEquals(address.getAddressCountry(), mappedAddress.getAddressCountry());
-        assertEquals(address.getAddressRegion(), mappedAddress.getAddressRegion());
-        assertEquals(address.getAddressLocality(), mappedAddress.getAddressLocality());
+            personIdentityDrivingPermit.setPersonalNumber("personalNumber");
+            personIdentityDrivingPermit.setExpiryDate(LocalDate.of(2029, 10, 21).toString());
+            personIdentityDrivingPermit.setIssueDate(LocalDate.of(2011, 10, 21).toString());
+            personIdentityDrivingPermit.setIssueNumber("issueNumber");
+            personIdentityDrivingPermit.setIssuedBy("issuedBy");
+            personIdentityDrivingPermit.setFullAddress("fullAddress");
 
-        assertEquals(address.getBuildingNumber(), mappedAddress.getBuildingNumber());
-        assertEquals(address.getBuildingName(), mappedAddress.getBuildingName());
-        assertEquals(address.getDepartmentName(), mappedAddress.getDepartmentName());
-        assertEquals(
-                address.getDependentAddressLocality(), mappedAddress.getDependentAddressLocality());
-        assertEquals(address.getDependentStreetName(), mappedAddress.getDependentStreetName());
-        assertEquals(
-                address.getDoubleDependentAddressLocality(),
-                mappedAddress.getDoubleDependentAddressLocality());
-        assertEquals(address.getOrganisationName(), mappedAddress.getOrganisationName());
-        assertEquals(address.getPostalCode(), mappedAddress.getPostalCode());
-        assertEquals(address.getStreetName(), mappedAddress.getStreetName());
-        assertEquals(address.getSubBuildingName(), mappedAddress.getSubBuildingName());
-        assertEquals(address.getUprn(), mappedAddress.getUprn());
+            PersonIdentityItem testPersonIdentityItem = new PersonIdentityItem();
+            testPersonIdentityItem.setNames(List.of(name));
+            testPersonIdentityItem.setBirthDates(List.of(birthDate));
+            testPersonIdentityItem.setAddresses(List.of(address));
+            testPersonIdentityItem.setSocialSecurityRecords(
+                    List.of(personIdentitySocialSecurityRecord));
+            testPersonIdentityItem.setDrivingPermits(List.of(personIdentityDrivingPermit));
 
-        DrivingPermit mappedDrivingPermit = mappedPersonIdentity.getDrivingPermits().get(0);
-        assertEquals(
-                personIdentityDrivingPermit.getPersonalNumber(),
-                mappedDrivingPermit.getPersonalNumber());
-        assertEquals(
-                personIdentityDrivingPermit.getExpiryDate(), mappedDrivingPermit.getExpiryDate());
-        assertEquals(
-                personIdentityDrivingPermit.getIssueDate(), mappedDrivingPermit.getIssueDate());
-        assertEquals(
-                personIdentityDrivingPermit.getIssueNumber(), mappedDrivingPermit.getIssueNumber());
-        assertEquals(personIdentityDrivingPermit.getIssuedBy(), mappedDrivingPermit.getIssuedBy());
-        assertEquals(
-                personIdentityDrivingPermit.getFullAddress(), mappedDrivingPermit.getFullAddress());
+            mappedPersonIdentity =
+                    personIdentityMapper.mapToPersonIdentityDetailed(testPersonIdentityItem);
+        }
 
-        // CRIs using a java backend currently shouldn't have a nino sent to them,
-        // functionality has been added in case this changes in the future but for now
-        // this checks the value hasn't been mapped into the personIdentity
-        assertNull(mappedPersonIdentity.getSocialSecurityRecords());
+        @Test
+        void shouldMapNameParts() {
+            List<NamePart> mappedNameParts = mappedPersonIdentity.getNames().get(0).getNameParts();
+            assertEquals(firstNamePart.getValue(), mappedNameParts.get(0).getValue());
+            assertEquals(firstNamePart.getType(), mappedNameParts.get(0).getType());
+            assertEquals(surnamePart.getValue(), mappedNameParts.get(1).getValue());
+            assertEquals(surnamePart.getType(), mappedNameParts.get(1).getType());
+            assertEquals(
+                    birthDate.getValue(), mappedPersonIdentity.getBirthDates().get(0).getValue());
+        }
+
+        @Test
+        void shouldMapBirthDay() {
+            assertEquals(
+                    birthDate.getValue(), mappedPersonIdentity.getBirthDates().get(0).getValue());
+        }
+
+        @Test
+        void shouldMapAddress() {
+            Address mappedAddress = mappedPersonIdentity.getAddresses().get(0);
+            assertEquals(address.getAddressCountry(), mappedAddress.getAddressCountry());
+            assertEquals(address.getAddressRegion(), mappedAddress.getAddressRegion());
+            assertEquals(address.getAddressLocality(), mappedAddress.getAddressLocality());
+
+            assertEquals(address.getBuildingNumber(), mappedAddress.getBuildingNumber());
+            assertEquals(address.getBuildingName(), mappedAddress.getBuildingName());
+            assertEquals(address.getDepartmentName(), mappedAddress.getDepartmentName());
+            assertEquals(
+                    address.getDependentAddressLocality(),
+                    mappedAddress.getDependentAddressLocality());
+            assertEquals(address.getDependentStreetName(), mappedAddress.getDependentStreetName());
+            assertEquals(
+                    address.getDoubleDependentAddressLocality(),
+                    mappedAddress.getDoubleDependentAddressLocality());
+            assertEquals(address.getOrganisationName(), mappedAddress.getOrganisationName());
+            assertEquals(address.getPostalCode(), mappedAddress.getPostalCode());
+            assertEquals(address.getStreetName(), mappedAddress.getStreetName());
+            assertEquals(address.getSubBuildingName(), mappedAddress.getSubBuildingName());
+            assertEquals(address.getUprn(), mappedAddress.getUprn());
+        }
+
+        @Test
+        void shouldMapDrivingPermit() {
+            DrivingPermit mappedDrivingPermit = mappedPersonIdentity.getDrivingPermits().get(0);
+            assertEquals(
+                    personIdentityDrivingPermit.getPersonalNumber(),
+                    mappedDrivingPermit.getPersonalNumber());
+            assertEquals(
+                    personIdentityDrivingPermit.getExpiryDate(),
+                    mappedDrivingPermit.getExpiryDate());
+            assertEquals(
+                    personIdentityDrivingPermit.getIssueDate(), mappedDrivingPermit.getIssueDate());
+            assertEquals(
+                    personIdentityDrivingPermit.getIssueNumber(),
+                    mappedDrivingPermit.getIssueNumber());
+            assertEquals(
+                    personIdentityDrivingPermit.getIssuedBy(), mappedDrivingPermit.getIssuedBy());
+            assertEquals(
+                    personIdentityDrivingPermit.getFullAddress(),
+                    mappedDrivingPermit.getFullAddress());
+        }
+
+        @Test
+        void socialSecurityRecordsShouldBeNull() {
+            // CRIs using a java backend currently shouldn't have a nino sent to them,
+            // functionality has been added in case this changes in the future but for now
+            // this checks the value hasn't been mapped into the personIdentity
+            assertNull(mappedPersonIdentity.getSocialSecurityRecords());
+        }
     }
 
     @Test

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapperTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapperTest.java
@@ -62,6 +62,7 @@ class PersonIdentityMapperTest {
         address.setStreetName("street");
         address.setAddressLocality("locality");
         address.setPostalCode("postcode");
+        address.setAddressRegion("dummyRegion");
         address.setValidFrom(TODAY);
 
         PersonIdentitySocialSecurityRecord socialSecurityRecord =
@@ -87,6 +88,7 @@ class PersonIdentityMapperTest {
         assertEquals(address.getAddressLocality(), mappedAddress.getAddressLocality());
         assertEquals(address.getPostalCode(), mappedAddress.getPostalCode());
         assertEquals(address.getValidFrom(), mappedAddress.getValidFrom());
+        assertEquals(address.getAddressRegion(), mappedAddress.getAddressRegion());
         assertEquals(AddressType.CURRENT, mappedAddress.getAddressType());
         assertEquals(
                 socialSecurityRecord.getPersonalNumber(),
@@ -166,6 +168,7 @@ class PersonIdentityMapperTest {
         previousAddress.setBuildingNumber("buildingNum");
         previousAddress.setStreetName("street");
         previousAddress.setPostalCode("postcode");
+        previousAddress.setAddressRegion("dummyRegion");
         previousAddress.setValidUntil(TODAY.minus(1L, ChronoUnit.DAYS));
 
         PersonIdentityItem testPersonIdentityItem = new PersonIdentityItem();
@@ -205,6 +208,7 @@ class PersonIdentityMapperTest {
         address.setStreetName("street");
         address.setAddressLocality("locality");
         address.setPostalCode("postcode");
+        address.setAddressRegion("dummyRegion");
         address.setValidFrom(TODAY);
         sharedClaims.setAddresses(List.of(address));
 
@@ -231,6 +235,7 @@ class PersonIdentityMapperTest {
         assertEquals(address.getBuildingNumber(), mappedAddress.getBuildingNumber());
         assertEquals(address.getStreetName(), mappedAddress.getStreetName());
         assertEquals(address.getPostalCode(), mappedAddress.getPostalCode());
+        assertEquals(address.getAddressRegion(), mappedAddress.getAddressRegion());
         assertEquals(TODAY, mappedAddress.getValidFrom());
         assertNull(mappedAddress.getValidUntil());
         assertEquals(
@@ -342,6 +347,7 @@ class PersonIdentityMapperTest {
             assertNull(mappedAddress.getBuildingNumber());
             assertNull(mappedAddress.getStreetName());
             assertEquals(expectedPostcode, mappedAddress.getPostalCode());
+            assertNull(mappedAddress.getAddressRegion());
             assertNull(mappedAddress.getValidFrom());
             assertNull(mappedAddress.getValidUntil());
         } else {
@@ -372,6 +378,7 @@ class PersonIdentityMapperTest {
 
         CanonicalAddress address = new CanonicalAddress();
         address.setAddressCountry("GB");
+        address.setAddressRegion("dummyRegion");
         address.setAddressLocality("locality");
         address.setBuildingNumber("buildingNum");
         address.setBuildingName("buildingName");
@@ -418,6 +425,7 @@ class PersonIdentityMapperTest {
         assertEquals(birthDate.getValue(), mappedPersonIdentity.getBirthDates().get(0).getValue());
         Address mappedAddress = mappedPersonIdentity.getAddresses().get(0);
         assertEquals(address.getAddressCountry(), mappedAddress.getAddressCountry());
+        assertEquals(address.getAddressRegion(), mappedAddress.getAddressRegion());
         assertEquals(address.getAddressLocality(), mappedAddress.getAddressLocality());
 
         assertEquals(address.getBuildingNumber(), mappedAddress.getBuildingNumber());


### PR DESCRIPTION
## Proposed changes

### What changed

Following on from 3.2.0 release, this adds addressRegion to Address

Refactored shouldMapPersonIdentityItemToPersonIdentityDetailed as the test had too many asserts and was flagging as a code smell. 

Adds SQ exclusion for `Address.java`. This is flagging duplication with CanonicalAddress. 
`property "sonar.cpd.exclusions", "**/di/ipv/cri/common/library/domain/personidentity/Address.java"`
Note: I did attempt `// NOSONAR` on the specific lines I have added to avoid excluding the whole file but it did not work. 

### Why did it change

Also add the field to Address object. 

### Issue tracking

- [OJ-2816](https://govukverify.atlassian.net/browse/OJ-2816)

[OJ-2816]: https://govukverify.atlassian.net/browse/OJ-2816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ