### PR TITLE
LIME-1384 ClientProviderFactory - select an AwsCredentialsProvider based on the current runtime environment

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 3.7.0
+
+    - ClientProviderFactory selects the appropriate AwsCredentialsProvider to use for AWS clients (EnvironmentVariableCredentialsProvider/ContainerCredentialsProvider.builder) based the current init environment - lambda snap start container or lambda run-time init environment.
+
 ## 3.6.0
 
     - Added @Deprecated tag to unused SQS helper class as tests now uses new test harness implemention

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "3.6.0"
+def buildVersion = "3.7.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/DataStore.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/DataStore.java
@@ -38,6 +38,7 @@ public class DataStore<T> {
      * To be removed as, calling this will not allow sharing a single DynamoDbEnhancedClient.
      *
      * @deprecated
+     * @return DynamoDbEnhancedClient
      */
     @SuppressWarnings("java:S1133")
     @Deprecated(forRemoval = true)

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/ClientProviderFactoryTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/ClientProviderFactoryTest.java
@@ -4,6 +4,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
@@ -14,6 +17,7 @@ import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(MockitoExtension.class)
@@ -27,8 +31,32 @@ class ClientProviderFactoryTest {
     void setUp() {
         environmentVariables.set("AWS_REGION", "eu-west-2");
         environmentVariables.set("AWS_STACK_NAME", "TEST_STACK");
+        environmentVariables.set("AWS_CONTAINER_CREDENTIALS_FULL_URI", null);
 
         clientProviderFactory = new ClientProviderFactory();
+    }
+
+    @Test
+    void shouldSelectEnvironmentVariableCredentialsProvider() {
+        environmentVariables.set("AWS_CONTAINER_CREDENTIALS_FULL_URI", null);
+
+        ClientProviderFactory thisTestOnly = new ClientProviderFactory();
+
+        AwsCredentialsProvider awsCredentialsProvider = thisTestOnly.getAwsCredentialsProvider();
+        assertNotNull(awsCredentialsProvider);
+        assertEquals(
+                EnvironmentVariableCredentialsProvider.class, awsCredentialsProvider.getClass());
+    }
+
+    @Test
+    void shouldSelectContainerCredentialsProvider() {
+        environmentVariables.set("AWS_CONTAINER_CREDENTIALS_FULL_URI", "TEST_URI");
+
+        ClientProviderFactory thisTestOnly = new ClientProviderFactory();
+
+        AwsCredentialsProvider awsCredentialsProvider = thisTestOnly.getAwsCredentialsProvider();
+        assertNotNull(awsCredentialsProvider);
+        assertEquals(ContainerCredentialsProvider.class, awsCredentialsProvider.getClass());
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed

ClientProviderFactory selects the appropriate AwsCredentialsProvider to use for AWS clients (EnvironmentVariableCredentialsProvider/ContainerCredentialsProvider.builder) based the current init environment - lambda snap start container or lambda run-time init environment.

### Why did it change

Java SnapStart creation runs within a container and can only access credentials via ContainerCredentialsProvider. With non-snap start code able to access EnvironmentVariableCredentialsProvider.

This provides support for snap-start and non-snap-start Java lambda configurations.

### Issue tracking

- [LIME-1384](https://govukverify.atlassian.net/browse/LIME-1384)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[LIME-1384]: https://govukverify.atlassian.net/browse/LIME-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ