### PR TITLE
Oj 2737 test harness tests

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 3.5.0
+
+    - Event endpoint is updated to use two parameters both sessionId and eventName that is passed in the feature file
+
 ## 3.4.0
 
     - Adds addressRegion to Address

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## 3.5.0
 
-    - Event endpoint is updated to use two parameters both sessionId and eventName that is passed in the feature file
+    - sendEventRequest method now accepts `eventName` parameter as an additional filter
 
 ## 3.4.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "3.4.0"
+def buildVersion = "3.4.1"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "3.4.1"
+def buildVersion = "3.5.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/TestResourcesClient.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/TestResourcesClient.java
@@ -43,7 +43,8 @@ public class TestResourcesClient {
         }
     }
 
-    public HttpExecuteResponse sendEventRequest(String sessionId) throws IOException {
+    public HttpExecuteResponse sendEventRequest(String sessionId, String eventName)
+            throws IOException {
         final URI eventsEndpointURI =
                 new URIBuilder(this.testHarnessUrl)
                         .setPath("events")
@@ -52,7 +53,11 @@ public class TestResourcesClient {
                                 URLEncoder.encode(
                                         String.format("%s%s", "SESSION#", sessionId),
                                         StandardCharsets.UTF_8))
-                        .addParameter("sortKey", "TXMA")
+                        .addParameter(
+                                "sortKey",
+                                URLEncoder.encode(
+                                        String.format("%s%s", "TXMA#", eventName),
+                                        StandardCharsets.UTF_8))
                         .build();
 
         final SdkHttpFullRequest request =

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CommonSteps.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CommonSteps.java
@@ -126,10 +126,11 @@ public class CommonSteps {
         this.testContext.setResponse(this.commonApiClient.sendTokenRequest(privateKeyJWT));
     }
 
-    @When("user sends a GET request to events end point")
-    public void userSendsAGetRequestToEventsEndpoint() throws IOException {
+    @When("user sends a GET request to events end point for {string}")
+    public void userSendsAGetRequestToEventsEndpoint(String eventName) throws IOException {
         this.testContext.setResponse(
-                this.testResourcesClient.sendEventRequest(this.testContext.getSessionId()));
+                this.testResourcesClient.sendEventRequest(
+                        this.testContext.getSessionId(), eventName));
     }
 
     @Then("user gets a session-id")


### PR DESCRIPTION
## Proposed changes

### What changed

`sendEventRequest` method now accepts `eventName` parameter as an additional filter to be used in feature file

### Why did it change

To assist with test harness implementation in kbv

### Issue tracking

- [OJ-2737](https://govukverify.atlassian.net/browse/OJ-2737)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2737]: https://govukverify.atlassian.net/browse/OJ-2737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ