### PR TITLE
OJ-2821: Check sessionId is present before validating session

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 4.1.0
+
+    - Adds null and blank check to the sessionID passed into validateSession, now throws SessionNotFoundException instead of a DynamoDBException
+
 ## 4.0.0
 
     - In ClientProviderFactory add support for manual opentelemetry instrumentation of AWS SDK clients and allow excluding SDK clients used by Powertools providers.

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "4.0.0"
+def buildVersion = "4.1.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
@@ -82,6 +82,10 @@ public class SessionService {
     public SessionItem validateSessionId(String sessionId)
             throws SessionNotFoundException, SessionExpiredException {
 
+        if (sessionId == null || sessionId.isBlank()) {
+            throw new SessionNotFoundException("session id empty");
+        }
+
         SessionItem sessionItem = dataStore.getItem(sessionId);
         setSessionItemsToLogging(sessionItem);
         if (sessionItem == null) {

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
@@ -35,7 +35,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -174,6 +176,21 @@ class SessionServiceTest {
         when(mockDataStore.getItem(SESSION_ID)).thenReturn(null);
         assertThrows(
                 SessionNotFoundException.class, () -> sessionService.validateSessionId(SESSION_ID));
+    }
+
+    @Test
+    void shouldThrowSessionNotFoundWhenSessionIdNull() {
+        assertThrows(SessionNotFoundException.class, () -> sessionService.validateSessionId(null));
+        verify(mockDataStore, never()).getItem(any());
+    }
+
+    @Test
+    void shouldThrowSessionNotFoundWhenSessionIdBlank() {
+        assertThrows(SessionNotFoundException.class, () -> sessionService.validateSessionId(""));
+        verify(mockDataStore, never()).getItem(any());
+
+        assertThrows(SessionNotFoundException.class, () -> sessionService.validateSessionId("   "));
+        verify(mockDataStore, never()).getItem(any());
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed

Added a _empty_ check to the `sessionId` in `validateSession` prior to calling DDB, and returns a `SessionNotFoundException` instead of a `DynamoDbException`.

### Why did it change

If `validateSession` was called with an 'empty' String it would still search DynamoDB and result in a `DynamoDbException` - Supplied AttributeValue is empty, must contain exactly one of the supported datatypes

### Issue tracking
- [OJ-2821](https://govukverify.atlassian.net/browse/OJ-2821)


[OJ-2821]: https://govukverify.atlassian.net/browse/OJ-2821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ