### PR TITLE
OJ-3124: Use Instant.now() on all clock calls (v5.0.0)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 5.0.0
+
+    - Replace the usage of Clock#instant with Instant.now()
+
 ## 4.2.0
 
     - Adds a generic RetryManager that allows for retry logic

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "4.2.0"
+def buildVersion = "5.0.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactory.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactory.java
@@ -8,7 +8,7 @@ import uk.gov.di.ipv.cri.common.library.domain.DeviceInformation;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
 import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 
-import java.time.Clock;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 
@@ -18,9 +18,8 @@ public class AuditEventFactory {
 
     private final String eventPrefix;
     private final String issuer;
-    private final Clock clock;
 
-    public AuditEventFactory(ConfigurationService configurationService, Clock clock) {
+    public AuditEventFactory(ConfigurationService configurationService) {
         this.eventPrefix = configurationService.getSqsAuditEventPrefix();
         if (StringUtils.isBlank(this.eventPrefix)) {
             throw new IllegalStateException(
@@ -30,14 +29,13 @@ public class AuditEventFactory {
         if (StringUtils.isBlank(this.issuer)) {
             throw new IllegalStateException("Issuer not retrieved from configuration service");
         }
-        this.clock = Objects.requireNonNull(clock, "clock must not be null");
     }
 
     <T> AuditEvent<T> create(String eventType, AuditEventContext auditEventContext, T extensions) {
         AuditEvent<T> auditEvent =
                 new AuditEvent<>(
-                        clock.instant().getEpochSecond(),
-                        clock.instant().toEpochMilli(),
+                        Instant.now().getEpochSecond(),
+                        Instant.now().toEpochMilli(),
                         eventPrefix + "_" + eventType,
                         issuer);
         if (Objects.nonNull(auditEventContext)) {

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationService.java
@@ -4,7 +4,7 @@ import software.amazon.lambda.powertools.parameters.SSMProvider;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 
-import java.time.Clock;
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.Objects;
@@ -19,7 +19,6 @@ public class ConfigurationService {
     private final String parameterPrefix;
     private final String commonParameterPrefix;
     private final String secretPrefix;
-    private final Clock clock;
 
     public enum SSMParameterName {
         SESSION_TTL("SessionTtl"),
@@ -43,8 +42,7 @@ public class ConfigurationService {
                 System.getenv("AWS_STACK_NAME"),
                 System.getenv("COMMON_PARAMETER_NAME_PREFIX"),
                 Optional.ofNullable(System.getenv("SECRET_PREFIX"))
-                        .orElse(System.getenv("AWS_STACK_NAME")),
-                Clock.systemUTC());
+                        .orElse(System.getenv("AWS_STACK_NAME")));
     }
 
     ConfigurationService(
@@ -52,14 +50,12 @@ public class ConfigurationService {
             SecretsProvider secretsProvider,
             String parameterPrefix,
             String commonParameterPrefix,
-            String secretPrefix,
-            Clock clock) {
+            String secretPrefix) {
         this.ssmProvider = ssmProvider;
         this.secretsProvider = secretsProvider;
         this.parameterPrefix = parameterPrefix;
         this.commonParameterPrefix = commonParameterPrefix;
         this.secretPrefix = secretPrefix;
-        this.clock = clock;
     }
 
     public String getParameterValue(String parameterName) {
@@ -91,7 +87,7 @@ public class ConfigurationService {
     }
 
     public long getSessionExpirationEpoch() {
-        return clock.instant().plus(getSessionTtl(), ChronoUnit.SECONDS).getEpochSecond();
+        return Instant.now().plus(getSessionTtl(), ChronoUnit.SECONDS).getEpochSecond();
     }
 
     public long getAuthorizationCodeTtl() {
@@ -101,7 +97,7 @@ public class ConfigurationService {
     }
 
     public long getAuthorizationCodeExpirationEpoch() {
-        return clock.instant().plus(getAuthorizationCodeTtl(), ChronoUnit.SECONDS).getEpochSecond();
+        return Instant.now().plus(getAuthorizationCodeTtl(), ChronoUnit.SECONDS).getEpochSecond();
     }
 
     public long getBearerAccessTokenTtl() {
@@ -111,7 +107,7 @@ public class ConfigurationService {
     }
 
     public long getBearerAccessTokenExpirationEpoch() {
-        return clock.instant().plus(getBearerAccessTokenTtl(), ChronoUnit.SECONDS).getEpochSecond();
+        return Instant.now().plus(getBearerAccessTokenTtl(), ChronoUnit.SECONDS).getEpochSecond();
     }
 
     public long getMaxJwtTtl() {

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java
@@ -1,9 +1,12 @@
 package uk.gov.di.ipv.cri.common.library.service;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.lambda.powertools.parameters.SSMProvider;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
@@ -11,12 +14,11 @@ import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
-import java.time.Clock;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith({MockitoExtension.class, SystemStubsExtension.class})
 class ConfigurationServiceTest {
@@ -26,23 +28,31 @@ class ConfigurationServiceTest {
     private static final String PARAM_VALUE = "param-value";
     @Mock private SSMProvider mockSsmProvider;
     @Mock private SecretsProvider mockSecretsProvider;
-    @Mock private Clock mockClock;
     private ConfigurationService configurationService;
 
     @SystemStub
     private EnvironmentVariables environment =
             new EnvironmentVariables("AWS_REGION", "eu-west-2", "AWS_STACK_NAME", "my-stack-name");
 
+    @Mock private ConfigurationService mockConfigurationService;
+
+    private MockedStatic<Instant> mockedStatic;
+
+    @AfterEach
+    void afterEach() {
+        mockedStatic.close();
+    }
+
     @BeforeEach
     void setUp() {
+        mockedStatic = Mockito.mockStatic(Instant.class);
         configurationService =
                 new ConfigurationService(
                         mockSsmProvider,
                         mockSecretsProvider,
                         TEST_STACK_NAME,
                         null,
-                        TEST_STACK_NAME,
-                        mockClock);
+                        TEST_STACK_NAME);
     }
 
     @Test
@@ -68,12 +78,7 @@ class ConfigurationServiceTest {
         String secretPrefix = "customSecretPrefix";
         configurationService =
                 new ConfigurationService(
-                        mockSsmProvider,
-                        mockSecretsProvider,
-                        TEST_STACK_NAME,
-                        null,
-                        secretPrefix,
-                        mockClock);
+                        mockSsmProvider, mockSecretsProvider, TEST_STACK_NAME, null, secretPrefix);
         String secretName = "my-secret-name";
         String secretValue = "secret-value";
         String fullSecretName = String.format(PARAM_NAME_FORMAT, secretPrefix, secretName);
@@ -84,6 +89,7 @@ class ConfigurationServiceTest {
 
     @Test
     void shouldGetSessionExpirationEpoch() {
+        long mockEpochSeconds = 1655203417;
         long sessionTtl = 10;
         when(mockSsmProvider.get(
                         String.format(
@@ -91,7 +97,14 @@ class ConfigurationServiceTest {
                                 TEST_STACK_NAME,
                                 ConfigurationService.SSMParameterName.SESSION_TTL.parameterName)))
                 .thenReturn(String.valueOf(sessionTtl));
-        when(mockClock.instant()).thenReturn(Instant.ofEpochSecond(1655203417));
+
+        Instant mockInstant = mock(Instant.class);
+        Instant mockExpiration = mock(Instant.class);
+
+        when(mockInstant.plus(anyLong(), eq(ChronoUnit.SECONDS))).thenReturn(mockExpiration);
+        when(mockExpiration.getEpochSecond()).thenReturn(mockEpochSeconds + sessionTtl);
+        mockedStatic.when(Instant::now).thenReturn(mockInstant);
+
         assertEquals(1655203427, configurationService.getSessionExpirationEpoch());
     }
 
@@ -116,8 +129,7 @@ class ConfigurationServiceTest {
                         mockSecretsProvider,
                         TEST_STACK_NAME,
                         commonParamPrefix,
-                        TEST_STACK_NAME,
-                        mockClock);
+                        TEST_STACK_NAME);
 
         when(mockSsmProvider.get(String.format(PARAM_NAME_FORMAT, commonParamPrefix, PARAM_NAME)))
                 .thenReturn(PARAM_VALUE);

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
@@ -23,9 +23,7 @@ import uk.gov.di.ipv.cri.common.library.persistence.item.EvidenceRequest;
 import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 
 import java.net.URI;
-import java.time.Clock;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
@@ -61,8 +59,7 @@ class SessionServiceTest {
 
     @BeforeEach
     void setUp() {
-        Clock nowClock = Clock.fixed(fixedInstant, ZoneId.systemDefault());
-        sessionService = new SessionService(mockDataStore, mockConfigurationService, nowClock);
+        sessionService = new SessionService(mockDataStore, mockConfigurationService);
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed
Removed all usage of Clock and updated the places it was used with `Instant.now()`

### Why did it change
With the introduction to SnapStart in some of our CRIs, the locally used `Clock` object stores the time that the snapshot was taken by AWS. This causes problems because calls to `clock.instant()` returns an Instant object that could be far in the past, causing values such as TTLs to be incorrect. 

In this PR, we now directly use `Instant.now()` so that regardless of SnapStart, it will always return the correct current time. 
Additionally, opted for using Instant.now() as opposed to a new clock instance as it's a better/less verbose/streamlined way to get the Instant object.


### Issue tracking
- [OJ-3124](https://govukverify.atlassian.net/browse/OJ-3124)


[OJ-3124]: https://govukverify.atlassian.net/browse/OJ-3124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ