### PR TITLE
OJ-2972: use public JWKs endpoint to verify JWTs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 5.0.0
+    - Adds a helper class to invoke the public JWKS endpoint and deserialize its response
+    - In the JWTVerifier, to use the provided public JWK endpoint if they are enabled via the ENV_VAR_FEATURE_FLAG_KEY_ROTATION and PUBLIC_JWKS_ENDPOINT environment variable.
+
 ## 4.2.0
 
     - Adds a generic RetryManager that allows for retry logic

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## 5.0.0
     - Adds a helper class to invoke the public JWKS endpoint and deserialize its response
-    - In the JWTVerifier, to use the provided public JWK endpoint if they are enabled via the ENV_VAR_FEATURE_FLAG_KEY_ROTATION and PUBLIC_JWKS_ENDPOINT environment variable.
+    - In the JWTVerifier, to use the provided public JWK endpoint if they are enabled via the ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK and PUBLIC_JWKS_ENDPOINT environment variable.
 
 ## 4.2.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "4.2.0"
+def buildVersion = "5.0.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/jwks/JWKS.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/jwks/JWKS.java
@@ -1,0 +1,34 @@
+package uk.gov.di.ipv.cri.common.library.domain.jwks;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JWKS {
+    @JsonProperty("keys")
+    private List<Key> keys;
+
+    private int maxAgeFromCacheControlHeader;
+
+    public JWKS() {
+        // Empty constructor for Jackson
+    }
+
+    public List<Key> getKeys() {
+        return keys;
+    }
+
+    public void setKeys(List<Key> keys) {
+        this.keys = keys;
+    }
+
+    public int getMaxAgeFromCacheControlHeader() {
+        return maxAgeFromCacheControlHeader;
+    }
+
+    public void setMaxAgeFromCacheControlHeader(int maxAgeFromCacheControlHeader) {
+        this.maxAgeFromCacheControlHeader = maxAgeFromCacheControlHeader;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/jwks/Key.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/jwks/Key.java
@@ -1,0 +1,110 @@
+package uk.gov.di.ipv.cri.common.library.domain.jwks;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Key {
+    @JsonProperty("kty")
+    private String kty;
+
+    @JsonProperty("e")
+    private String e;
+
+    @JsonProperty("use")
+    private String use;
+
+    @JsonProperty("crv")
+    private String crv;
+
+    @JsonProperty("alg")
+    private String alg;
+
+    @JsonProperty("n")
+    private String n;
+
+    @JsonProperty("x")
+    private String x;
+
+    @JsonProperty("y")
+    private String y;
+
+    @JsonProperty("kid")
+    private String kid;
+
+    public Key() {
+        // Empty constructor for Jackson
+    }
+
+    public String getKty() {
+        return kty;
+    }
+
+    public void setKty(String kty) {
+        this.kty = kty;
+    }
+
+    public String getE() {
+        return e;
+    }
+
+    public void setE(String e) {
+        this.e = e;
+    }
+
+    public String getUse() {
+        return use;
+    }
+
+    public void setUse(String use) {
+        this.use = use;
+    }
+
+    public String getAlg() {
+        return alg;
+    }
+
+    public void setAlg(String alg) {
+        this.alg = alg;
+    }
+
+    public String getN() {
+        return n;
+    }
+
+    public void setN(String n) {
+        this.n = n;
+    }
+
+    public String getKid() {
+        return kid;
+    }
+
+    public void setKid(String kid) {
+        this.kid = kid;
+    }
+
+    public String getX() {
+        return x;
+    }
+
+    public void setX(String x) {
+        this.x = x;
+    }
+
+    public String getY() {
+        return y;
+    }
+
+    public void setY(String y) {
+        this.y = y;
+    }
+
+    public String getCrv() {
+        return crv;
+    }
+
+    public void setCrv(String crv) {
+        this.crv = crv;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/exception/JWKSRequestException.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/exception/JWKSRequestException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.cri.common.library.exception;
+
+public class JWKSRequestException extends Exception {
+    public JWKSRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkKeyCache.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkKeyCache.java
@@ -1,0 +1,86 @@
+package uk.gov.di.ipv.cri.common.library.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.cri.common.library.domain.jwks.JWKS;
+import uk.gov.di.ipv.cri.common.library.domain.jwks.Key;
+import uk.gov.di.ipv.cri.common.library.exception.JWKSRequestException;
+
+import java.util.Base64;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+public class JwkKeyCache {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Logger LOGGER = LoggerFactory.getLogger(JwkKeyCache.class);
+
+    private final boolean usePublicJwk;
+    private final String publicJwkEndpoint;
+    private final JwkRequest jwkRequest;
+
+    private JWKS cachedJwks;
+    private long lastUpdated;
+    private long cacheControl;
+
+    public JwkKeyCache() {
+        this(new JwkRequest());
+    }
+
+    public JwkKeyCache(JwkRequest jwkRequest) {
+        this.jwkRequest = jwkRequest;
+        this.lastUpdated = 0;
+        this.cacheControl = 0;
+        usePublicJwk =
+                Boolean.parseBoolean(
+                        Optional.ofNullable(System.getenv("ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK"))
+                                .orElse("false"));
+        publicJwkEndpoint = System.getenv("PUBLIC_JWKS_ENDPOINT");
+    }
+
+    public JwkKeyCache(JwkRequest jwkRequest, boolean usePublicJwk, String publicJwkEndpoint) {
+        this.jwkRequest = jwkRequest;
+        this.lastUpdated = 0;
+        this.cacheControl = 0;
+        this.usePublicJwk = usePublicJwk;
+        this.publicJwkEndpoint = publicJwkEndpoint;
+    }
+
+    public Optional<String> getBase64JwkForKid(String kid) {
+        if (!usePublicJwk || publicJwkEndpoint == null) {
+            LOGGER.info("Using public JWKs endpoint is disabled");
+            return Optional.empty();
+        }
+        LOGGER.info("Using JWKs endpoint: {}", publicJwkEndpoint);
+        if (cachedJwks == null || System.currentTimeMillis() > lastUpdated + cacheControl) {
+            try {
+                cachedJwks = jwkRequest.callJWKSEndpoint(publicJwkEndpoint);
+            } catch (JWKSRequestException e) {
+                LOGGER.error("Failed to call JWK endpoint ({})", publicJwkEndpoint, e);
+                return Optional.empty();
+            }
+            lastUpdated = System.currentTimeMillis();
+            cacheControl = TimeUnit.SECONDS.toMillis(cachedJwks.getMaxAgeFromCacheControlHeader());
+            LOGGER.info("JWKs cache has been updated");
+        } else {
+            LOGGER.info("Using locally cached JWKs from {}", publicJwkEndpoint);
+        }
+        return getKeyForKid(cachedJwks, kid).map(this::toBase64);
+    }
+
+    private Optional<Key> getKeyForKid(JWKS jwks, String kid) {
+        return jwks.getKeys().stream()
+                .filter(entry -> entry.getUse().equals("sig") && entry.getKid().equals(kid))
+                .findFirst();
+    }
+
+    private String toBase64(Key key) {
+        try {
+            String str = OBJECT_MAPPER.writeValueAsString(key);
+            return Base64.getEncoder().encodeToString(str.getBytes());
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkKeyCache.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkKeyCache.java
@@ -62,7 +62,9 @@ public class JwkKeyCache {
             }
             lastUpdated = System.currentTimeMillis();
             cacheControl = TimeUnit.SECONDS.toMillis(cachedJwks.getMaxAgeFromCacheControlHeader());
-            LOGGER.info("JWKs cache has been updated to '{}' seconds", cachedJwks.getMaxAgeFromCacheControlHeader());
+            LOGGER.info(
+                    "JWKs cache has been updated to '{}' seconds",
+                    cachedJwks.getMaxAgeFromCacheControlHeader());
         } else {
             LOGGER.info("Using locally cached JWKs from {}", publicJwkEndpoint);
         }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkKeyCache.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkKeyCache.java
@@ -62,7 +62,7 @@ public class JwkKeyCache {
             }
             lastUpdated = System.currentTimeMillis();
             cacheControl = TimeUnit.SECONDS.toMillis(cachedJwks.getMaxAgeFromCacheControlHeader());
-            LOGGER.info("JWKs cache has been updated");
+            LOGGER.info("JWKs cache has been updated to '{}' seconds", cachedJwks.getMaxAgeFromCacheControlHeader());
         } else {
             LOGGER.info("Using locally cached JWKs from {}", publicJwkEndpoint);
         }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkKeyCache.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkKeyCache.java
@@ -66,10 +66,10 @@ public class JwkKeyCache {
         } else {
             LOGGER.info("Using locally cached JWKs from {}", publicJwkEndpoint);
         }
-        return getKeyForKid(cachedJwks, kid).map(this::toBase64);
+        return getSigningKeyForKid(cachedJwks, kid).map(this::toBase64);
     }
 
-    private Optional<Key> getKeyForKid(JWKS jwks, String kid) {
+    private Optional<Key> getSigningKeyForKid(JWKS jwks, String kid) {
         return jwks.getKeys().stream()
                 .filter(entry -> entry.getUse().equals("sig") && entry.getKid().equals(kid))
                 .findFirst();

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkRequest.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkRequest.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 
 public class JwkRequest {
     private static final Logger LOGGER = LoggerFactory.getLogger(JwkRequest.class);
+    private static final String CACHE_CONTROL_HEADER_NAME = "Cache-Control";
+    private static final String MAX_AGE_PREFIX = "max-age=";
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
 
@@ -55,12 +57,12 @@ public class JwkRequest {
 
     private Optional<Integer> parseCacheControlHeader(HttpResponse<String> response) {
         return response.headers()
-                .firstValue("Cache-Control")
-                .filter(value -> value.startsWith("max-age="))
+                .firstValue(CACHE_CONTROL_HEADER_NAME)
+                .filter(value -> value.startsWith(MAX_AGE_PREFIX))
                 .map(
                         value -> {
                             try {
-                                return Integer.parseInt(value.substring("max-age=".length()));
+                                return Integer.parseInt(value.substring(MAX_AGE_PREFIX.length()));
                             } catch (NumberFormatException e) {
                                 LOGGER.warn(
                                         "Invalid max-age value in Cache-Control header: {}",

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkRequest.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkRequest.java
@@ -1,0 +1,73 @@
+package uk.gov.di.ipv.cri.common.library.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.cri.common.library.domain.jwks.JWKS;
+import uk.gov.di.ipv.cri.common.library.exception.JWKSRequestException;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Optional;
+
+public class JwkRequest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JwkRequest.class);
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    public JwkRequest() {
+        this(HttpClient.newHttpClient(), new ObjectMapper());
+    }
+
+    public JwkRequest(HttpClient httpClient, ObjectMapper objectMapper) {
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+    }
+
+    public JWKS callJWKSEndpoint(String endpoint) throws JWKSRequestException {
+        try {
+            HttpRequest request = createRequest(endpoint);
+            HttpResponse<String> response = sendRequest(request);
+            JWKS jwks = objectMapper.readValue(response.body(), JWKS.class);
+            parseCacheControlHeader(response).ifPresent(jwks::setMaxAgeFromCacheControlHeader);
+            return jwks;
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new JWKSRequestException("Failed to retrieve JWKS from endpoint: " + endpoint, e);
+        }
+    }
+
+    private HttpRequest createRequest(String endpoint) throws JWKSRequestException {
+        try {
+            return HttpRequest.newBuilder().uri(new URI(endpoint)).GET().build();
+        } catch (Exception e) {
+            throw new JWKSRequestException("Failed to create request for endpoint: " + endpoint, e);
+        }
+    }
+
+    private HttpResponse<String> sendRequest(HttpRequest request)
+            throws IOException, InterruptedException {
+        return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private Optional<Integer> parseCacheControlHeader(HttpResponse<String> response) {
+        return response.headers()
+                .firstValue("Cache-Control")
+                .filter(value -> value.startsWith("max-age="))
+                .map(
+                        value -> {
+                            try {
+                                return Integer.parseInt(value.substring("max-age=".length()));
+                            } catch (NumberFormatException e) {
+                                LOGGER.warn(
+                                        "Invalid max-age value in Cache-Control header: {}",
+                                        value,
+                                        e);
+                                return 0;
+                            }
+                        });
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/JwkKeyCacheTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/JwkKeyCacheTest.java
@@ -1,0 +1,57 @@
+package uk.gov.di.ipv.cri.common.library.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.domain.jwks.JWKS;
+import uk.gov.di.ipv.cri.common.library.domain.jwks.Key;
+
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JwkKeyCacheTest {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Mock private JwkRequest mockJwkRequest;
+
+    @Test
+    void shouldFetchJwk() throws Exception {
+        String kid = "dummyKid";
+
+        JWKS jwks = new JWKS();
+        jwks.setMaxAgeFromCacheControlHeader(300);
+
+        Key key = new Key();
+        key.setUse("sig");
+        key.setKid(kid);
+
+        jwks.setKeys(List.of(key));
+
+        when(mockJwkRequest.callJWKSEndpoint(anyString())).thenReturn(jwks);
+
+        JwkKeyCache jwkKeyCache = new JwkKeyCache(mockJwkRequest, true, "https://example.com");
+        Optional<String> jwk = jwkKeyCache.getBase64JwkForKid(kid);
+
+        String base64Key =
+                Base64.getEncoder()
+                        .encodeToString(OBJECT_MAPPER.writeValueAsString(key).getBytes());
+
+        assertTrue(jwk.isPresent());
+        assertEquals(base64Key, jwk.get());
+    }
+
+    @Test
+    void shouldReturnEmptyWhenDisabled() {
+        assertTrue(
+                new JwkKeyCache(mockJwkRequest, false, "").getBase64JwkForKid("dummy").isEmpty());
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/JwkKeyCacheTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/JwkKeyCacheTest.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/JwkRequestTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/JwkRequestTest.java
@@ -1,0 +1,122 @@
+package uk.gov.di.ipv.cri.common.library.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.domain.jwks.JWKS;
+import uk.gov.di.ipv.cri.common.library.domain.jwks.Key;
+import uk.gov.di.ipv.cri.common.library.exception.JWKSRequestException;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JwkRequestTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Mock private HttpClient mockHttpClient;
+    @Mock private HttpResponse<Object> mockHttpResponse;
+    @Mock private HttpHeaders mockHttpHeaders;
+
+    private static final String MOCK_API_RESPONSE =
+            "{\n"
+                    + "  \"keys\": [\n"
+                    + "    {\n"
+                    + "      \"kty\": \"RSA\",\n"
+                    + "      \"e\": \"AQAB\",\n"
+                    + "      \"use\": \"enc\",\n"
+                    + "      \"alg\": \"RS256\",\n"
+                    + "      \"n\": \"dummy-n\",\n"
+                    + "      \"kid\": \"dummy-kid\"\n"
+                    + "    },\n"
+                    + "    {\n"
+                    + "      \"kty\": \"EC\",\n"
+                    + "      \"use\": \"sig\",\n"
+                    + "      \"crv\": \"P-256\",\n"
+                    + "      \"x\": \"dummy-x\",\n"
+                    + "      \"y\": \"dummy-y\",\n"
+                    + "      \"alg\": \"ES256\",\n"
+                    + "      \"kid\": \"dummy-kid\"\n"
+                    + "    }\n"
+                    + "  ]\n"
+                    + "}";
+
+    @Test
+    void shouldReturnCacheControlHeader() throws Exception {
+        when(mockHttpClient.send(any(), any())).thenReturn(mockHttpResponse);
+        when(mockHttpResponse.body()).thenReturn(MOCK_API_RESPONSE);
+        when(mockHttpResponse.headers()).thenReturn(mockHttpHeaders);
+        when(mockHttpHeaders.firstValue("Cache-Control")).thenReturn(Optional.of("max-age=300"));
+
+        JwkRequest request = new JwkRequest(mockHttpClient, objectMapper);
+        JWKS jwks = request.callJWKSEndpoint("https://example.com/.well-known/jwks.json");
+        assertEquals(300, jwks.getMaxAgeFromCacheControlHeader());
+    }
+
+    @Test
+    void cacheControlHeaderZero() throws Exception {
+        when(mockHttpClient.send(any(), any())).thenReturn(mockHttpResponse);
+        when(mockHttpResponse.body()).thenReturn(MOCK_API_RESPONSE);
+        when(mockHttpResponse.headers()).thenReturn(mockHttpHeaders);
+        when(mockHttpHeaders.firstValue("Cache-Control")).thenReturn(Optional.of("invalid"));
+
+        JwkRequest request = new JwkRequest(mockHttpClient, objectMapper);
+        JWKS jwks = request.callJWKSEndpoint("https://example.com/.well-known/jwks.json");
+        assertEquals(0, jwks.getMaxAgeFromCacheControlHeader());
+    }
+
+    @Test
+    void shouldReturnKeys() throws Exception {
+        when(mockHttpClient.send(any(), any())).thenReturn(mockHttpResponse);
+        when(mockHttpResponse.body()).thenReturn(MOCK_API_RESPONSE);
+        when(mockHttpResponse.headers()).thenReturn(mockHttpHeaders);
+
+        JwkRequest request = new JwkRequest(mockHttpClient, objectMapper);
+        JWKS jwks = request.callJWKSEndpoint("https://example.com/.well-known/jwks.json");
+
+        List<Key> keys = jwks.getKeys();
+
+        assertEquals(2, keys.size());
+        assertEquals("RSA", keys.get(0).getKty());
+        assertEquals("AQAB", keys.get(0).getE());
+        assertEquals("enc", keys.get(0).getUse());
+        assertEquals("RS256", keys.get(0).getAlg());
+        assertEquals("dummy-n", keys.get(0).getN());
+        assertEquals("dummy-kid", keys.get(0).getKid());
+        assertNull(keys.get(0).getX());
+
+        assertEquals("EC", keys.get(1).getKty());
+        assertEquals("sig", keys.get(1).getUse());
+        assertEquals("P-256", keys.get(1).getCrv());
+        assertEquals("dummy-x", keys.get(1).getX());
+        assertEquals("dummy-y", keys.get(1).getY());
+        assertEquals("ES256", keys.get(1).getAlg());
+        assertEquals("dummy-kid", keys.get(1).getKid());
+    }
+
+    @Test
+    void showThrowNPEWhenInvalidURL() {
+        JwkRequest request = new JwkRequest(HttpClient.newHttpClient(), objectMapper);
+        assertThrows(JWKSRequestException.class, () -> request.callJWKSEndpoint("not-valid-url"));
+    }
+
+    @Test
+    void showThrowErrorWhenInvalidBody() throws IOException, InterruptedException {
+        when(mockHttpClient.send(any(), any())).thenReturn(mockHttpResponse);
+        when(mockHttpResponse.body()).thenReturn("invalid-response");
+
+        JwkRequest request = new JwkRequest(mockHttpClient, objectMapper);
+        assertThrows(
+                JWKSRequestException.class,
+                () -> request.callJWKSEndpoint("https://example.com/.well-known/jwks.json"));
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/JwkRequestTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/JwkRequestTest.java
@@ -16,8 +16,11 @@ import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -59,6 +62,12 @@ class JwkRequestTest {
 
         JwkRequest request = new JwkRequest(mockHttpClient, objectMapper);
         JWKS jwks = request.callJWKSEndpoint("https://example.com/.well-known/jwks.json");
+
+        verify(mockHttpClient).send(any(), any());
+        verify(mockHttpResponse).body();
+        verify(mockHttpResponse).headers();
+        verify(mockHttpHeaders).firstValue("Cache-Control");
+
         assertEquals(300, jwks.getMaxAgeFromCacheControlHeader());
     }
 
@@ -71,6 +80,12 @@ class JwkRequestTest {
 
         JwkRequest request = new JwkRequest(mockHttpClient, objectMapper);
         JWKS jwks = request.callJWKSEndpoint("https://example.com/.well-known/jwks.json");
+
+        verify(mockHttpClient).send(any(), any());
+        verify(mockHttpResponse).body();
+        verify(mockHttpResponse).headers();
+        verify(mockHttpHeaders).firstValue("Cache-Control");
+
         assertEquals(0, jwks.getMaxAgeFromCacheControlHeader());
     }
 
@@ -84,6 +99,10 @@ class JwkRequestTest {
         JWKS jwks = request.callJWKSEndpoint("https://example.com/.well-known/jwks.json");
 
         List<Key> keys = jwks.getKeys();
+
+        verify(mockHttpClient).send(any(), any());
+        verify(mockHttpResponse).body();
+        verify(mockHttpResponse).headers();
 
         assertEquals(2, keys.size());
         assertEquals("RSA", keys.get(0).getKty());
@@ -115,6 +134,7 @@ class JwkRequestTest {
         when(mockHttpResponse.body()).thenReturn("invalid-response");
 
         JwkRequest request = new JwkRequest(mockHttpClient, objectMapper);
+
         assertThrows(
                 JWKSRequestException.class,
                 () -> request.callJWKSEndpoint("https://example.com/.well-known/jwks.json"));


### PR DESCRIPTION
## Proposed changes

### What changed
* Added  code to invoke the `/.well-known/jwks.json` endpoint
* Added code to cache the response + respect the Cache-Control header
* Updated JWTVerifier to use the key from the jwks endpoint - will default to previous behaviour on failure

**Screenshots**
AccessTokenFunction Log Group:
<img width="561" alt="Screenshot 2025-04-28 at 10 34 58" src="https://github.com/user-attachments/assets/b438b121-f021-4bd5-baa0-9e923b4fca93" />
<img width="593" alt="Screenshot 2025-04-28 at 10 34 32" src="https://github.com/user-attachments/assets/010aa785-4b62-40b5-9467-e0d449763d0d" />
<img width="548" alt="Screenshot 2025-04-28 at 10 34 21" src="https://github.com/user-attachments/assets/ea28cd89-d691-4269-84d6-067d98fadd3b" />


SessionFunction Log Group:

When Disabled:
<img width="534" alt="Screenshot 2025-04-28 at 10 36 23" src="https://github.com/user-attachments/assets/06d411a9-fbe2-430f-b0c1-f820cb897ecf" />


### Issue tracking
- [OJ-2972](https://govukverify.atlassian.net/browse/OJ-2972)


[OJ-2972]: https://govukverify.atlassian.net/browse/OJ-2972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ