### PR TITLE
OJ-2972: fix NPE with  getSigningKeyForKid

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Credential Issuer common libraries Release Notes
 
+## 5.0.1
+    - Add a null check to getSignignKeyForKid
+
 ## 5.0.0
     - Adds a helper class to invoke the public JWKS endpoint and deserialize its response
     - In the JWTVerifier, to use the provided public JWK endpoint if they are enabled via the ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK and PUBLIC_JWKS_ENDPOINT environment variable.

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "5.0.0"
+def buildVersion = "5.0.1"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/jwks/JWKS.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/jwks/JWKS.java
@@ -13,7 +13,7 @@ public class JWKS {
     private int maxAgeFromCacheControlHeader;
 
     public JWKS() {
-        // Empty constructor for Jackson
+        maxAgeFromCacheControlHeader = 0;
     }
 
     public List<Key> getKeys() {

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkKeyCache.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkKeyCache.java
@@ -72,6 +72,9 @@ public class JwkKeyCache {
     }
 
     private Optional<Key> getSigningKeyForKid(JWKS jwks, String kid) {
+        if (jwks == null || jwks.getKeys() == null) {
+            return Optional.empty();
+        }
         return jwks.getKeys().stream()
                 .filter(entry -> entry.getUse().equals("sig") && entry.getKid().equals(kid))
                 .findFirst();

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/JwkKeyCacheTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/JwkKeyCacheTest.java
@@ -50,6 +50,21 @@ class JwkKeyCacheTest {
     }
 
     @Test
+    void shouldReturnEmptyWhenNullJwk() throws Exception {
+        String kid = "dummyKid";
+
+        JWKS jwks = new JWKS();
+        jwks.setMaxAgeFromCacheControlHeader(300);
+
+        when(mockJwkRequest.callJWKSEndpoint(anyString())).thenReturn(jwks);
+
+        JwkKeyCache jwkKeyCache = new JwkKeyCache(mockJwkRequest, true, "https://example.com");
+        Optional<String> jwk = jwkKeyCache.getBase64JwkForKid(kid);
+
+        assertTrue(jwk.isEmpty());
+    }
+
+    @Test
     void shouldReturnEmptyWhenDisabled() {
         assertTrue(
                 new JwkKeyCache(mockJwkRequest, false, "").getBase64JwkForKid("dummy").isEmpty());


### PR DESCRIPTION

## Proposed changes

### What changed
Added a null check to getSigningKeyForKid

### Why did it change
Noticed a NPE when the request to the public jwk endpoint fails. 

### Issue tracking
- [KBV-2972](https://govukverify.atlassian.net/browse/KBV-2972)
