### PR TITLE
OJ-2677: Update tests to use new headless core stub

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Credential Issuer common libraries Release Notes
 
+## 5.1.0
+    - Add /start request endpoint for the headless core stub implementation updating it based on default or overwritten test scenarios
+    - Create new /token and /authorization endpoint specifically for the headless core stub
+    - Create Stub Client file to generate the client assertion for the /token endpoint to use in replace of ipvCoreStubClient file
+
 ## 5.0.2
     - throw JWKSRequestException in callJWKSEndpoint when the JWKS endpoint does not return a 200
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "5.0.2"
+def buildVersion = "5.1.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 
@@ -160,6 +160,8 @@ dependencies {
 	testFixturesApi configurations.cloudformation
 	testFixturesApi	configurations.cucumber
 	testFixturesApi	configurations.aspectjrt
+	testFixturesApi configurations.nimbus
+	testFixturesApi configurations.ssm
 
 	testFixturesImplementation configurations.jackson
 	testFixturesImplementation configurations.tests

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/CommonApiClient.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/CommonApiClient.java
@@ -16,11 +16,13 @@ import java.net.http.HttpResponse;
 public class CommonApiClient {
     private final HttpClient httpClient;
     private final ClientConfigurationService clientConfigurationService;
+    private final TestResourcesClient testResourcesClient;
 
     private static final String JSON_MIME_MEDIA_TYPE = "application/json";
 
     public CommonApiClient(ClientConfigurationService clientConfigurationService) {
         this.clientConfigurationService = clientConfigurationService;
+        this.testResourcesClient = new TestResourcesClient(clientConfigurationService);
         this.httpClient = HttpClient.newBuilder().build();
     }
 
@@ -59,7 +61,7 @@ public class CommonApiClient {
                         .setPath(this.clientConfigurationService.createUriPath("authorization"))
                         .addParameter(
                                 "redirect_uri",
-                                new URIBuilder("https://test-resources.review-a.dev.account.gov.uk")
+                                new URIBuilder(testResourcesClient.getTestHarnessUrl())
                                         .setPath("/callback")
                                         .build()
                                         .toString())

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/CommonApiClient.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/CommonApiClient.java
@@ -1,8 +1,14 @@
 package uk.gov.di.ipv.cri.common.library.client;
 
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import uk.gov.di.ipv.cri.common.library.util.URIBuilder;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -31,6 +37,33 @@ public class CommonApiClient {
                                         .toString())
                         .addParameter(
                                 "client_id", this.clientConfigurationService.getDefaultClientId())
+                        .addParameter("response_type", "code")
+                        .addParameter("scope", "openid")
+                        .addParameter("state", "state-ipv")
+                        .build();
+
+        var request =
+                HttpRequest.newBuilder()
+                        .uri(url)
+                        .header(HttpHeaders.ACCEPT, JSON_MIME_MEDIA_TYPE)
+                        .header(HttpHeaders.SESSION_ID, sessionId)
+                        .GET()
+                        .build();
+        return sendHttpRequest(request);
+    }
+
+    public HttpResponse<String> sendNewAuthorizationRequest(String sessionId)
+            throws IOException, InterruptedException {
+        var url =
+                new URIBuilder(this.clientConfigurationService.getPrivateApiEndpoint())
+                        .setPath(this.clientConfigurationService.createUriPath("authorization"))
+                        .addParameter(
+                                "redirect_uri",
+                                new URIBuilder("https://test-resources.review-a.dev.account.gov.uk")
+                                        .setPath("/callback")
+                                        .build()
+                                        .toString())
+                        .addParameter("client_id", "ipv-core-stub-aws-headless")
                         .addParameter("response_type", "code")
                         .addParameter("scope", "openid")
                         .addParameter("state", "state-ipv")
@@ -104,6 +137,41 @@ public class CommonApiClient {
                                 HttpHeaders.API_KEY,
                                 this.clientConfigurationService.getPublicApiKey())
                         .POST(HttpRequest.BodyPublishers.ofString(privateKeyJwt))
+                        .build();
+        return sendHttpRequest(request);
+    }
+
+    public HttpResponse<String> sendNewTokenRequest(
+            PrivateKeyJWT privateKeyJwt, String code, String issuer)
+            throws IOException, InterruptedException, URISyntaxException {
+        var authorisationGrant =
+                new AuthorizationCodeGrant(
+                        new AuthorizationCode(code), new URI(issuer + "/callback"));
+        var tokenRequest =
+                new TokenRequest(
+                        new URIBuilder(this.clientConfigurationService.getPublicApiEndpoint())
+                                .setPath(this.clientConfigurationService.createUriPath("token"))
+                                .build(),
+                        privateKeyJwt,
+                        authorisationGrant);
+
+        var tokenRequestBody = tokenRequest.toHTTPRequest();
+
+        var request =
+                HttpRequest.newBuilder()
+                        .uri(
+                                new URIBuilder(
+                                                this.clientConfigurationService
+                                                        .getPublicApiEndpoint())
+                                        .setPath(
+                                                this.clientConfigurationService.createUriPath(
+                                                        "token"))
+                                        .build())
+                        .header(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded")
+                        .header(
+                                HttpHeaders.API_KEY,
+                                this.clientConfigurationService.getPublicApiKey())
+                        .POST(HttpRequest.BodyPublishers.ofString(tokenRequestBody.getBody()))
                         .build();
         return sendHttpRequest(request);
     }

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/StubClient.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/StubClient.java
@@ -28,6 +28,8 @@ public class StubClient {
         ssmClient = new ClientProviderFactory().getSsmClient();
     }
 
+    private static final long hourTimeLimit = 3600_000;
+
     public PrivateKeyJWT generateClientAssertion(String issuer, String audience)
             throws JOSEException, ParseException {
         var claimsSetValues =
@@ -38,7 +40,7 @@ public class StubClient {
                         .claim(JWTClaimNames.JWT_ID, UUID.randomUUID())
                         .claim(
                                 JWTClaimNames.EXPIRATION_TIME,
-                                new Date(new Date().getTime() + 3600_000))
+                                new Date(new Date().getTime() + hourTimeLimit))
                         .build();
 
         ECDSASigner signer = new ECDSASigner(getEcPrivateKey());
@@ -65,7 +67,7 @@ public class StubClient {
             GetParameterResponse parameterResponse = ssmClient.getParameter(parameterRequest);
             return parameterResponse.parameter().value();
         } catch (SsmException e) {
-            System.err.println(e.getMessage());
+            e.getMessage();
             throw e;
         }
     }

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/StubClient.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/StubClient.java
@@ -1,0 +1,72 @@
+package uk.gov.di.ipv.cri.common.library.client;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jwt.JWTClaimNames;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
+import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
+import software.amazon.awssdk.services.ssm.model.SsmException;
+import uk.gov.di.ipv.cri.common.library.util.ClientProviderFactory;
+
+import java.text.ParseException;
+import java.util.Date;
+import java.util.UUID;
+
+public class StubClient {
+    SsmClient ssmClient;
+
+    public StubClient() {
+
+        ssmClient = new ClientProviderFactory().getSsmClient();
+    }
+
+    public PrivateKeyJWT generateClientAssertion(String issuer, String audience)
+            throws JOSEException, ParseException {
+        var claimsSetValues =
+                new JWTClaimsSet.Builder()
+                        .claim(JWTClaimNames.ISSUER, issuer)
+                        .claim(JWTClaimNames.SUBJECT, issuer)
+                        .claim(JWTClaimNames.AUDIENCE, audience)
+                        .claim(JWTClaimNames.JWT_ID, UUID.randomUUID())
+                        .claim(
+                                JWTClaimNames.EXPIRATION_TIME,
+                                new Date(new Date().getTime() + 3600_000))
+                        .build();
+
+        ECDSASigner signer = new ECDSASigner(getEcPrivateKey());
+
+        JWSHeader jwtHeader =
+                new JWSHeader.Builder(JWSAlgorithm.ES256).type(JOSEObjectType.JWT).build();
+        SignedJWT signedJWT = new SignedJWT(jwtHeader, claimsSetValues);
+        signedJWT.sign(signer);
+
+        return new PrivateKeyJWT(signedJWT);
+    }
+
+    private ECKey getEcPrivateKey() throws ParseException {
+        return ECKey.parse(getParameterValueByAbsoluteName());
+    }
+
+    private String getParameterValueByAbsoluteName() {
+        try {
+            GetParameterRequest parameterRequest =
+                    GetParameterRequest.builder()
+                            .name("/test-resources/ipv-core-stub-aws-headless/privateSigningKey")
+                            .build();
+
+            GetParameterResponse parameterResponse = ssmClient.getParameter(parameterRequest);
+            return parameterResponse.parameter().value();
+        } catch (SsmException e) {
+            System.err.println(e.getMessage());
+            throw e;
+        }
+    }
+}

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/TestResourcesClient.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/TestResourcesClient.java
@@ -1,6 +1,11 @@
 package uk.gov.di.ipv.cri.common.library.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.JWTClaimsSet;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.HttpExecuteRequest;
 import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.SdkHttpClient;
@@ -14,17 +19,23 @@ import software.amazon.awssdk.utils.IoUtils;
 import uk.gov.di.ipv.cri.common.library.aws.CloudFormationHelper;
 import uk.gov.di.ipv.cri.common.library.util.URIBuilder;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 public class TestResourcesClient {
     private final String testHarnessUrl;
 
     private static final SdkHttpClient CLIENT = AwsCrtHttpClient.builder().build();
     private static final AwsV4HttpSigner SIGNER = AwsV4HttpSigner.create();
+    private static final String JSON_MIME_MEDIA_TYPE = "application/json";
 
     public TestResourcesClient(ClientConfigurationService clientConfigurationService) {
         this.testHarnessUrl =
@@ -69,6 +80,58 @@ public class TestResourcesClient {
         return sendRequest(request);
     }
 
+    public HttpResponse<String> sendOverwrittenStartRequest(
+            String sharedClaim, String evidenceRequested, Map<String, Object> claimOverrides)
+            throws IOException, InterruptedException {
+        final URI startEndpointURI = new URIBuilder(this.testHarnessUrl).setPath("start").build();
+        String requestBody = buildStartRequestBody(sharedClaim, evidenceRequested, claimOverrides);
+        final SdkHttpFullRequest request =
+                SdkHttpFullRequest.builder()
+                        .method(SdkHttpMethod.POST)
+                        .uri(startEndpointURI)
+                        .putHeader(HttpHeaders.CONTENT_TYPE, JSON_MIME_MEDIA_TYPE)
+                        .contentStreamProvider(ContentStreamProvider.fromUtf8String(requestBody))
+                        .build();
+
+        return sendSignedStartRequest(request, requestBody);
+    }
+
+    public HttpResponse<String> sendStartRequest() throws IOException, InterruptedException {
+        final URI startEndpointURI = new URIBuilder(this.testHarnessUrl).setPath("start").build();
+        String requestBody = "{}";
+        final SdkHttpFullRequest request =
+                SdkHttpFullRequest.builder()
+                        .method(SdkHttpMethod.POST)
+                        .uri(startEndpointURI)
+                        .putHeader(HttpHeaders.CONTENT_TYPE, JSON_MIME_MEDIA_TYPE)
+                        .contentStreamProvider(
+                                RequestBody.fromString(requestBody).contentStreamProvider())
+                        .build();
+
+        return sendSignedStartRequest(request, requestBody);
+    }
+
+    private HttpResponse<String> sendSignedStartRequest(
+            SdkHttpFullRequest unsignedRequest, String requestBody)
+            throws IOException, InterruptedException {
+        final SignedRequest signedRequest = signRequest(unsignedRequest);
+
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest.Builder request =
+                HttpRequest.newBuilder().POST(HttpRequest.BodyPublishers.ofString(requestBody));
+        request.uri(unsignedRequest.getUri());
+        signedRequest
+                .request()
+                .headers()
+                .forEach(
+                        (K, B) -> {
+                            if (!K.startsWith("Host")) {
+                                request.header(K, B.get(0));
+                            }
+                        });
+        return client.send(request.build(), HttpResponse.BodyHandlers.ofString());
+    }
+
     private HttpExecuteResponse sendRequest(SdkHttpFullRequest unsignedRequest) throws IOException {
         final SignedRequest signedRequest = signRequest(unsignedRequest);
 
@@ -84,14 +147,67 @@ public class TestResourcesClient {
     private SignedRequest signRequest(SdkHttpFullRequest unsignedRequest) {
         try (DefaultCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create()) {
             return SIGNER.sign(
-                    signRequest ->
-                            signRequest
-                                    .request(unsignedRequest)
-                                    .identity(credentialsProvider.resolveCredentials())
-                                    .putProperty(
-                                            AwsV4HttpSigner.SERVICE_SIGNING_NAME, "execute-api")
-                                    .putProperty(
-                                            AwsV4HttpSigner.REGION_NAME, Region.EU_WEST_2.id()));
+                    signRequest -> {
+                        signRequest
+                                .request(unsignedRequest)
+                                .payload(unsignedRequest.contentStreamProvider().orElse(null))
+                                .identity(credentialsProvider.resolveCredentials())
+                                .putProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, "execute-api")
+                                .putProperty(AwsV4HttpSigner.REGION_NAME, Region.EU_WEST_2.id());
+                    });
+        }
+    }
+
+    private static String buildStartRequestBody(
+            String sharedClaimsFile,
+            String evidenceRequestedFile,
+            Map<String, Object> claimOverrides)
+            throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Object sharedClaims = readJsonFromFile(sharedClaimsFile);
+        Object evidenceRequested = readJsonFromFile(evidenceRequestedFile);
+
+        JWTClaimsSet.Builder claimsSetBuilder = new JWTClaimsSet.Builder();
+
+        if (sharedClaims != null) {
+            claimsSetBuilder.claim("shared_claims", sharedClaims);
+        }
+
+        if (evidenceRequested != null) {
+            claimsSetBuilder.claim("evidence_requested", evidenceRequested);
+        }
+
+        if (claimOverrides != null && !claimOverrides.isEmpty()) {
+            claimOverrides.forEach(claimsSetBuilder::claim);
+        }
+
+        JWTClaimsSet jwtClaimsSet = claimsSetBuilder.build();
+        return mapper.writeValueAsString(jwtClaimsSet.toJSONObject());
+    }
+
+    private static Object readJsonFromFile(String overridesFileName) throws IOException {
+        if (overridesFileName.trim().isEmpty()) {
+            System.out.println("No file provided.");
+            return null;
+        }
+
+        InputStream input =
+                TestResourcesClient.class
+                        .getClassLoader()
+                        .getResourceAsStream("overrides/" + overridesFileName);
+        if (input == null) {
+            throw new FileNotFoundException(
+                    "Override JSON file not found: overrides/" + overridesFileName);
+        }
+
+        String fileContent = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+
+        try {
+            return new ObjectMapper().readValue(fileContent, Object.class);
+        } catch (JsonProcessingException e) {
+            throw new IOException(
+                    "Invalid JSON in file '" + overridesFileName + "': " + e.getMessage(), e);
         }
     }
 }

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CommonSteps.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CommonSteps.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
-import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
@@ -21,8 +20,6 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.http.HttpResponse;
 import java.text.ParseException;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -108,19 +105,12 @@ public class CommonSteps {
                         this.testContext.getSerialisedUserIdentity());
     }
 
-    @Given("user has an overridden signed JWT using {string} and {string}:")
-    public void userHasAnOverriddenSignedJWT(
-            String sharedClaims, String evidenceRequested, DataTable dataTable)
+    @Given("user has an overridden signed JWT using {string}")
+    public void userHasAnOverriddenSignedJWT(String claimOverrides)
             throws IOException, InterruptedException {
 
-        Map<String, Object> claimOverrides = new HashMap<>();
-        for (List<String> row : dataTable.asLists()) {
-            claimOverrides.put(row.get(0), row.get(1));
-        }
-
         HttpResponse<String> response =
-                this.testResourcesClient.sendOverwrittenStartRequest(
-                        sharedClaims, evidenceRequested, claimOverrides);
+                this.testResourcesClient.sendOverwrittenStartRequest(claimOverrides);
 
         assertEquals(200, response.statusCode());
         sessionRequestBody = response.body();

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CommonSteps.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CommonSteps.java
@@ -189,7 +189,6 @@ public class CommonSteps {
                 testContext.setResponse(response);
                 return;
             }
-            System.out.println("Attempt " + attempt + ": no event body returned - retrying");
             wait(delayMillis);
         }
         throw new AssertionError("No audit event body found for session");


### PR DESCRIPTION
## Proposed changes

### What changed

- Added the `/start` request endpoint to use for the default and overwritten test scenarios
- Added new `/token` and `/authorization` endpoint for the test resource client (so that it does not impact existing tests)
- Updated the `/events` endpoint to retry the request till the request body is there, to reduce errors
- Created a new Stub Client file to generate the client assertion for the `/token` endpoint to use in replace of ipvCoreStubClient file

### Why did it change

To use the headless, typescript core stub that has a /start endpoint that returns a JWT that can be used to start a session in any CRI frontend.

### Issue tracking

- [OJ-2677](https://govukverify.atlassian.net/browse/OJ-2677)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2677]: https://govukverify.atlassian.net/browse/OJ-2677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ