### PR TITLE
OJ-2972: Add a status code check to callJWKSEndpoint

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Credential Issuer common libraries Release Notes
 
+## 5.0.2
+    - throw JWKSRequestException in callJWKSEndpoint when the JWKS endpoint does not return a 200
+
 ## 5.0.1
     - Add a null check to getSignignKeyForKid
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "5.0.1"
+def buildVersion = "5.0.2"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/exception/JWKSRequestException.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/exception/JWKSRequestException.java
@@ -1,6 +1,10 @@
 package uk.gov.di.ipv.cri.common.library.exception;
 
 public class JWKSRequestException extends Exception {
+    public JWKSRequestException(String message) {
+        super(message);
+    }
+
     public JWKSRequestException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkRequest.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkRequest.java
@@ -33,6 +33,10 @@ public class JwkRequest {
         try {
             HttpRequest request = createRequest(endpoint);
             HttpResponse<String> response = sendRequest(request);
+            if (response.statusCode() != 200) {
+                throw new JWKSRequestException(
+                        "JWK endpoint returned status code " + response.statusCode());
+            }
             JWKS jwks = objectMapper.readValue(response.body(), JWKS.class);
             parseCacheControlHeader(response).ifPresent(jwks::setMaxAgeFromCacheControlHeader);
             return jwks;

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/JwkRequestTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/JwkRequestTest.java
@@ -139,4 +139,16 @@ class JwkRequestTest {
                 JWKSRequestException.class,
                 () -> request.callJWKSEndpoint("https://example.com/.well-known/jwks.json"));
     }
+
+    @Test
+    void showThrowErrorWhenNon200StatusCode() throws IOException, InterruptedException {
+        when(mockHttpClient.send(any(), any())).thenReturn(mockHttpResponse);
+        when(mockHttpResponse.statusCode()).thenReturn(403);
+
+        JwkRequest request = new JwkRequest(mockHttpClient, objectMapper);
+
+        assertThrows(
+                JWKSRequestException.class,
+                () -> request.callJWKSEndpoint("https://example.com/.well-known/jwks.json"));
+    }
 }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/JwkRequestTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/JwkRequestTest.java
@@ -57,6 +57,7 @@ class JwkRequestTest {
     void shouldReturnCacheControlHeader() throws Exception {
         when(mockHttpClient.send(any(), any())).thenReturn(mockHttpResponse);
         when(mockHttpResponse.body()).thenReturn(MOCK_API_RESPONSE);
+        when(mockHttpResponse.statusCode()).thenReturn(200);
         when(mockHttpResponse.headers()).thenReturn(mockHttpHeaders);
         when(mockHttpHeaders.firstValue("Cache-Control")).thenReturn(Optional.of("max-age=300"));
 
@@ -75,6 +76,7 @@ class JwkRequestTest {
     void cacheControlHeaderZero() throws Exception {
         when(mockHttpClient.send(any(), any())).thenReturn(mockHttpResponse);
         when(mockHttpResponse.body()).thenReturn(MOCK_API_RESPONSE);
+        when(mockHttpResponse.statusCode()).thenReturn(200);
         when(mockHttpResponse.headers()).thenReturn(mockHttpHeaders);
         when(mockHttpHeaders.firstValue("Cache-Control")).thenReturn(Optional.of("invalid"));
 
@@ -93,6 +95,7 @@ class JwkRequestTest {
     void shouldReturnKeys() throws Exception {
         when(mockHttpClient.send(any(), any())).thenReturn(mockHttpResponse);
         when(mockHttpResponse.body()).thenReturn(MOCK_API_RESPONSE);
+        when(mockHttpResponse.statusCode()).thenReturn(200);
         when(mockHttpResponse.headers()).thenReturn(mockHttpHeaders);
 
         JwkRequest request = new JwkRequest(mockHttpClient, objectMapper);
@@ -131,6 +134,7 @@ class JwkRequestTest {
     @Test
     void showThrowErrorWhenInvalidBody() throws IOException, InterruptedException {
         when(mockHttpClient.send(any(), any())).thenReturn(mockHttpResponse);
+        when(mockHttpResponse.statusCode()).thenReturn(200);
         when(mockHttpResponse.body()).thenReturn("invalid-response");
 
         JwkRequest request = new JwkRequest(mockHttpClient, objectMapper);


### PR DESCRIPTION
## Proposed changes

### What changed
Added a status code check to callJWKSEndpoint

### Why did it change
So that we're handling errors better. 

### Issue tracking
- [OJ-2972](https://govukverify.atlassian.net/browse/OJ-2972)


[OJ-2972]: https://govukverify.atlassian.net/browse/OJ-2972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ