### PR TITLE
OJ-2969: Integration jwks endpoint

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 5.2.0
+    - Added WellknownJwkHappyPath.feature which can be used by CRI's to test their
+    .well-known/jwks.json
+    
 ## 5.1.0
     - Add /start request endpoint for the headless core stub implementation updating it based on default or overwritten test scenarios
     - Create new /token and /authorization endpoint specifically for the headless core stub

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "5.1.0"
+def buildVersion = "5.2.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/config/ApiGatewayConfig.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/config/ApiGatewayConfig.java
@@ -1,0 +1,20 @@
+package uk.gov.di.ipv.cri.common.library.config;
+
+public class ApiGatewayConfig {
+    public String getPrivateApiEndpoint() {
+        return getApiEndpoint("API_GATEWAY_ID_PRIVATE");
+    }
+
+    public String getPublicApiEndpoint() {
+        return getApiEndpoint("API_GATEWAY_ID_PUBLIC");
+    }
+
+    public String getPublicApiKey() {
+        return getApiEndpoint("APIGW_API_KEY");
+    }
+
+    private String getApiEndpoint(String key) {
+        String id = EnvironmentConfig.getEnvironment(key);
+        return String.format("https://%s.execute-api.eu-west-2.amazonaws.com", id);
+    }
+}

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/config/EnvironmentConfig.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/config/EnvironmentConfig.java
@@ -1,0 +1,10 @@
+package uk.gov.di.ipv.cri.common.library.config;
+
+import java.util.Optional;
+
+public final class EnvironmentConfig {
+    public static String getEnvironment(String key) {
+        return Optional.ofNullable(System.getenv(key))
+                .orElseThrow(() -> new IllegalArgumentException("Missing env variable: " + key));
+    }
+}

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/helpers/HttpClientHelper.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/helpers/HttpClientHelper.java
@@ -1,0 +1,25 @@
+package uk.gov.di.ipv.cri.common.library.helpers;
+
+import uk.gov.di.ipv.cri.common.library.config.EnvironmentConfig;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class HttpClientHelper {
+    private final HttpClient httpClient;
+
+    public HttpClientHelper() {
+        this.httpClient = HttpClient.newBuilder().build();
+    }
+
+    public HttpResponse<String> sendHttpRequest(HttpRequest request)
+            throws IOException, InterruptedException {
+        return this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    public String createUriPath(String path) {
+        return String.format("/%s/%s", EnvironmentConfig.getEnvironment("ENVIRONMENT"), path);
+    }
+}

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/helpers/HttpResponseHelper.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/helpers/HttpResponseHelper.java
@@ -1,0 +1,15 @@
+package uk.gov.di.ipv.cri.common.library.helpers;
+
+import java.net.http.HttpResponse;
+
+public class HttpResponseHelper {
+    private HttpResponse<String> response;
+
+    public void setResponse(HttpResponse<String> response) {
+        this.response = response;
+    }
+
+    public HttpResponse<String> getResponse() {
+        return this.response;
+    }
+}

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/WellKnownJwksSteps.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/WellKnownJwksSteps.java
@@ -20,7 +20,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
 
 public class WellKnownJwksSteps {

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/WellKnownJwksSteps.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/WellKnownJwksSteps.java
@@ -1,0 +1,110 @@
+package uk.gov.di.ipv.cri.common.library.stepdefinitions;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import uk.gov.di.ipv.cri.common.library.config.ApiGatewayConfig;
+import uk.gov.di.ipv.cri.common.library.helpers.HttpClientHelper;
+import uk.gov.di.ipv.cri.common.library.helpers.HttpResponseHelper;
+import uk.gov.di.ipv.cri.common.library.util.URIBuilder;
+
+import java.io.IOException;
+import java.net.http.HttpRequest;
+import java.util.stream.StreamSupport;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+
+public class WellKnownJwksSteps {
+    private static final String JSON_MIME_MEDIA_TYPE = "application/json";
+    private String publicKeyJwksBasePath;
+    private final HttpResponseHelper httpResponse;
+    private final HttpClientHelper httpClientHelper;
+    private final ObjectMapper objectMapper;
+    private final ApiGatewayConfig apiGatewayConfig;
+
+    public WellKnownJwksSteps() {
+        this.httpClientHelper = new HttpClientHelper();
+        this.httpResponse = new HttpResponseHelper();
+        this.apiGatewayConfig = new ApiGatewayConfig();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Given("that a public \\/.well-known\\/jwks.json endpoint exists for CRI")
+    public void thatAPublicWellKnownJwksJsonEndpointExistsForCRI() {
+        publicKeyJwksBasePath = this.apiGatewayConfig.getPublicApiEndpoint();
+    }
+
+    @When("a request is made to fetch the public encryption keys")
+    public void a_request_is_made_to_fetch_the_public_encryption_keys()
+            throws IOException, InterruptedException {
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(
+                                new URIBuilder(publicKeyJwksBasePath)
+                                        .setPath(
+                                                this.httpClientHelper.createUriPath(
+                                                        ".well-known/jwks.json"))
+                                        .build())
+                        .header("Accept", JSON_MIME_MEDIA_TYPE)
+                        .GET()
+                        .build();
+
+        httpResponse.setResponse(this.httpClientHelper.sendHttpRequest(request));
+    }
+
+    @Then("the response from the endpoint includes the public JWK keyset")
+    public void the_response_from_the_endpoint_includes_the_public_jwk_keyset()
+            throws JsonProcessingException {
+        JsonNode jwkResponse = objectMapper.readTree(httpResponse.getResponse().body());
+
+        assertThat(200, is(httpResponse.getResponse().statusCode()));
+        assertThat(jwkResponse.has("keys"), is(true));
+        assertThat(jwkResponse.get("keys").isArray(), is(true));
+        assertThat(jwkResponse.get("keys").size(), greaterThan(0));
+
+        JsonNode firstKey = jwkResponse.get("keys").get(0);
+        assertThat(firstKey.get("kty").asText(), is("RSA"));
+        assertThat(firstKey.get("use").asText(), is("enc"));
+        assertThat(firstKey.get("alg").asText(), is("RSA_OAEP_256"));
+    }
+
+    @And("each key has an associated kid")
+    public void each_key_has_an_associated_kid() throws JsonProcessingException {
+        JsonNode jwkResponse = objectMapper.readTree(httpResponse.getResponse().body());
+
+        for (JsonNode key : jwkResponse.get("keys")) {
+
+            assertThat(key.has("n"), is(true));
+            assertThat(key.get("n").asText(), not(emptyOrNullString()));
+
+            assertThat(key.has("e"), is(true));
+            assertThat(key.get("e").asText(), not(emptyOrNullString()));
+
+            assertThat(key.has("kid"), is(true));
+            assertThat(key.get("kid").asText(), not(emptyOrNullString()));
+        }
+    }
+
+    @And("at least one key use is {string} for {string}")
+    public void at_least_one_key_use_is_for(String keyUse, String keyType)
+            throws JsonProcessingException {
+        JsonNode jwkResponse = objectMapper.readTree(httpResponse.getResponse().body());
+
+        boolean hasAKeyUse =
+                StreamSupport.stream(jwkResponse.get("keys").spliterator(), false)
+                        .anyMatch(key -> keyUse.equals(key.get("use").asText()));
+        assertThat(
+                "At least one key should be for" + keyType + "(use=" + keyUse + ")",
+                hasAKeyUse,
+                is(true));
+    }
+}


### PR DESCRIPTION
### Why did it change

Created `.well-known/jwks.json` for Address-cri see https://github.com/govuk-one-login/ipv-cri-address-api/pull/1276
This PR would enable to ability to run an integration-test for this new endpoint in the address-cri as shown in the screen-shot below

![image](https://github.com/user-attachments/assets/8bd3da6c-bd8e-4dd3-b886-1378ffccbf4f)

- [OJ-2969:](https://govukverify.atlassian.net/browse/OJ-2969:)

## Checklists

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] Documented in the [RELEASE_NOTES](./blob/main/RELEASE_NOTES.md)
- [ ] Updated build.gradle to 5.2.0

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks