### PR TITLE
OJ-3180: Increase delayBetweenAttempts when calling getSessionByAccessToken

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 5.2.1
+    - Add logging of the first attempt to RetryManager
+    - Increase delayBetweenAttempts in SessionService#getSessionByAccessToken
+
 ## 5.2.0
     - Added WellknownJwkHappyPath.feature which can be used by CRI's to test their
     .well-known/jwks.json

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "5.2.0"
+def buildVersion = "5.2.1"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
@@ -132,7 +132,7 @@ public class SessionService {
 
         RetryConfig retryConfig =
                 new RetryConfig.Builder()
-                        .delayBetweenAttempts(100)
+                        .delayBetweenAttempts(500)
                         .maxAttempts(3)
                         .exponentiallyRetry(true)
                         .build();

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/retry/RetryManager.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/retry/RetryManager.java
@@ -12,8 +12,12 @@ public class RetryManager {
     }
 
     public static <T> T execute(RetryConfig retryConfig, Retryable<T> retryable) {
-        for (int attempt = 0; attempt < retryConfig.getMaxAttempts(); attempt++) {
+        int maxAttempts = retryConfig.getMaxAttempts();
+
+        for (int attempt = 0; attempt < maxAttempts; attempt++) {
             try {
+                LOGGER.info("Retrying attempt {} of {}", attempt, maxAttempts);
+
                 if (attempt > 0) {
                     long start = System.currentTimeMillis();
                     long sleepDuration = calculateSleepDuration(retryConfig, attempt);
@@ -26,10 +30,7 @@ public class RetryManager {
 
                 T result = retryable.execute();
 
-                if (attempt > 0) {
-                    LOGGER.info("Retry succeeded on attempt {}", attempt);
-                }
-
+                LOGGER.info("Retry succeeded on attempt {}", attempt);
                 return result;
 
             } catch (InterruptedException ex) {


### PR DESCRIPTION
## Proposed changes

### What changed
* Updated RetryManager to log the first attempt and if it succeeded.
* Updated SessionService#getSessionByAccessToken and set the delayBetweenAttempts to 500ms

### Why did it change
When querying the session table by access token, it uses a GSI and it takes around a second for the base table to update. Previously, we waited 200ms and went up exponentially but with 3 attempts, the total time we spent retrying was 600ms (since attempt 0 isn't sleeping attempt). 

### Issue tracking
- [OJ-3180](https://govukverify.atlassian.net/browse/OJ-3180)


[OJ-3180]: https://govukverify.atlassian.net/browse/OJ-3180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ