### PR TITLE
OJ-3175: Retrieve JWKS endpoint URLs from SSM

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+# 6.1.0
+    - Retrieves JWKS endpoint for JWT verification from SSM params instead of an ENV variable
+    - Caches JWKS per endpoint instead of a single cache to allow for different clients
+
 # 6.0.0
     - Refactored step definitions to remove duplication for the authorization and token endpoint
     - Removed ipvCoreStub file and references to it 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "6.0.0"
+def buildVersion = "6.1.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/jwks/JWKS.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/jwks/JWKS.java
@@ -10,6 +10,8 @@ public class JWKS {
     @JsonProperty("keys")
     private List<Key> keys;
 
+    private long lastUpdated;
+    private long cacheControl;
     private int maxAgeFromCacheControlHeader;
 
     public JWKS() {
@@ -30,5 +32,21 @@ public class JWKS {
 
     public void setMaxAgeFromCacheControlHeader(int maxAgeFromCacheControlHeader) {
         this.maxAgeFromCacheControlHeader = maxAgeFromCacheControlHeader;
+    }
+
+    public long getLastUpdated() {
+        return lastUpdated;
+    }
+
+    public void setLastUpdated(long lastUpdated) {
+        this.lastUpdated = lastUpdated;
+    }
+
+    public long getCacheControl() {
+        return cacheControl;
+    }
+
+    public void setCacheControl(long cacheControl) {
+        this.cacheControl = cacheControl;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/JWTVerifier.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/JWTVerifier.java
@@ -129,7 +129,9 @@ public class JWTVerifier {
             }
 
             jwkKeyCache
-                    .getBase64JwkForKid(signedJWT.getHeader().getKeyID())
+                    .getBase64JwkForKid(
+                            clientAuthenticationConfig.get("jwksEndpoint"),
+                            signedJWT.getHeader().getKeyID())
                     .ifPresentOrElse(
                             value ->
                                     clientAuthenticationConfig.replace(


### PR DESCRIPTION
## Proposed changes

### What changed

JWKS Endpoints will now be retrieved from SSM instead of a single ENV variable to support different clients providing different endpoints. 
Caching has been updated so each endpoint is cached instead of a single cached JWKS.

### Why did it change

The CRIs need to consume the public signing key from the service that signed the JWT.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3175](https://govukverify.atlassian.net/browse/OJ-3175)


[OJ-3175]: https://govukverify.atlassian.net/browse/OJ-3175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ