### PR TITLE
Use a new HttpClient for each request in JwkRequest

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Credential Issuer common libraries Release Notes
 
+# 6.2.3
+    - Bug fix: use a new HttpClient in JwkRequest to fix work around GOAWAY frame
+
 # 6.2.2
     - Updated SessionService#getSessionByAuthorisationCode to retry in case of any failure due to GSI eventual consistentency
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "6.2.2"
+def buildVersion = "6.2.3"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkRequest.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkRequest.java
@@ -16,11 +16,12 @@ public class JwkRequest {
     private static final Logger LOGGER = LoggerFactory.getLogger(JwkRequest.class);
     private static final String CACHE_CONTROL_HEADER_NAME = "Cache-Control";
     private static final String MAX_AGE_PREFIX = "max-age=";
-    private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
 
+    private HttpClient httpClient;
+
     public JwkRequest() {
-        this(HttpClient.newHttpClient(), new ObjectMapper());
+        this(null, new ObjectMapper());
     }
 
     public JwkRequest(HttpClient httpClient, ObjectMapper objectMapper) {
@@ -58,9 +59,14 @@ public class JwkRequest {
 
     private HttpResponse<String> sendRequest(HttpRequest request) throws JWKSRequestException {
         try {
+            if (httpClient == null) {
+                httpClient = HttpClient.newBuilder().build();
+            }
             return httpClient.send(request, HttpResponse.BodyHandlers.ofString()); // NOSONAR
         } catch (Exception e) { // NOSONAR
             throw new JWKSRequestException("Failed to send HTTP request", e);
+        } finally {
+            httpClient = null;
         }
     }
 


### PR DESCRIPTION

## Proposed changes

### What changed
Use a new HttpClient for each request in JwkRequest

### Why did it change
`JWKSRequestException called with cause java.io.IOException: /169.254.76.1:37802: GOAWAY received` - suspected that the connection has been idling too long and AWS closes the connection. 
