### PR TITLE
fix: use http 1.1 in JwkRequest

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Credential Issuer common libraries Release Notes
 
+# 6.3.1
+    - Bug fix: use a HTTP 1.1 in JwkRequest to fix work around GOAWAY frame
+
 # 6.3.0
     - Changed EvidenceRequest types to prevent potential crashes caused by unboxing when null fields are present
     - Improved logging of verification scores in setSessionItemsToLogging method

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "6.3.0"
+def buildVersion = "6.3.1"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkRequest.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/JwkRequest.java
@@ -60,7 +60,7 @@ public class JwkRequest {
     private HttpResponse<String> sendRequest(HttpRequest request) throws JWKSRequestException {
         try {
             if (httpClient == null) {
-                httpClient = HttpClient.newBuilder().build();
+                httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
             }
             return httpClient.send(request, HttpResponse.BodyHandlers.ofString()); // NOSONAR
         } catch (Exception e) { // NOSONAR


### PR DESCRIPTION
## Proposed changes

### What changed
Used HTTP 1.1 in JwkRequest

### Why did it change
There's a bug with HttpClient not handling GOAWAY frame properly in HTTP2. 
