### PR TITLE
OJ-3210: Update KMSRSADecrypter 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Credential Issuer common libraries Release Notes
 
+# 6.4.0
+    - Update KMSRSADecrypter to achieve feature parity with the one in common-lambda, so that it can removed from eventually from common-lambda. 
+    - This class along with JweDecrypter are used in this library for testing purposes
+    - Common-lambda can now reference KMSRSADecrypter and JweDecrypter moved to this lib.
+
 # 6.3.1
     - Bug fix: use a HTTP 1.1 in JwkRequest to fix work around GOAWAY frame
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "6.3.1"
+def buildVersion = "6.4.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/KMSRSADecrypter.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/KMSRSADecrypter.java
@@ -39,6 +39,9 @@ public class KMSRSADecrypter implements JWEDecrypter {
             "session_decryption_key_previous_alias";
     private static final String ALL_ALIASES_UNAVAILABLE = "all_aliases_unavailable_for_decryption";
     private boolean keyRotationEnabled = false;
+    private final boolean keyRotationLegacyKeyFallbackEnabled =
+            Boolean.parseBoolean(
+                    System.getenv("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK"));
     private final JWEJCAContext jcaContext;
     private final KmsClient kmsClient;
     private final EventProbe eventProbe;
@@ -92,27 +95,51 @@ public class KMSRSADecrypter implements JWEDecrypter {
         DecryptResponse decryptResponse;
         if (isKeyRotationEnabled()) {
             LOGGER.info("Key rotation enabled. Attempting to decrypt with key aliases.");
-            // During a key rotation we might receive JWTs encrypted with either the old or new key.
+            // During a key rotation, we might receive JWTs encrypted with either the old or new
+            // key.
             decryptResponse = decryptWithKeyAliases(encryptedKey);
 
-            if (decryptResponse == null) {
+            if (keyRotationLegacyKeyFallbackEnabled && decryptResponse == null) {
+                LOGGER.warn(
+                        "Failed to decrypt with all available key aliases, falling back to legacy key.");
+
+                // Legacy Key fallback
+                try {
+                    decryptResponse = decryptWithLegacyKey(encryptedKey);
+                } catch (Exception e) {
+                    // Do nothing
+                }
+
+                if (decryptResponse == null) {
+                    String message = "Failed to decrypt with legacy key.";
+                    LOGGER.error(message);
+                    throw new JOSEException(message);
+                }
+
+                LOGGER.info("Decryption successful with legacy key");
+            } else if (decryptResponse == null) {
                 String message = "Failed to decrypt with all available key aliases.";
                 LOGGER.error(message);
                 throw new JOSEException(message);
             }
         } else {
-            DecryptRequest decryptRequest =
-                    DecryptRequest.builder()
-                            .encryptionAlgorithm(EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256)
-                            .ciphertextBlob(SdkBytes.fromByteArray(encryptedKey.decode()))
-                            .keyId(this.keyId)
-                            .build();
-            decryptResponse = this.kmsClient.decrypt(decryptRequest);
+            // Legacy Key Route
+            decryptResponse = decryptWithLegacyKey(encryptedKey);
         }
 
         SecretKey cek = new SecretKeySpec(decryptResponse.plaintext().asByteArray(), "AES");
         return ContentCryptoProvider.decrypt(
                 header, null, encryptedKey, iv, cipherText, authTag, cek, getJCAContext());
+    }
+
+    private DecryptResponse decryptWithLegacyKey(Base64URL encryptedKey) {
+        DecryptRequest decryptRequest =
+                DecryptRequest.builder()
+                        .encryptionAlgorithm(EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256)
+                        .ciphertextBlob(SdkBytes.fromByteArray(encryptedKey.decode()))
+                        .keyId(this.keyId)
+                        .build();
+        return this.kmsClient.decrypt(decryptRequest);
     }
 
     private DecryptResponse decryptWithKeyAliases(Base64URL encryptedKey) {
@@ -139,10 +166,6 @@ public class KMSRSADecrypter implements JWEDecrypter {
         return decryptResponse;
     }
 
-    public boolean isKeyRotationEnabled() {
-        return keyRotationEnabled;
-    }
-
     private DecryptRequest buildDecryptRequest(String keyAlias, Base64URL encryptedKey) {
         return DecryptRequest.builder()
                 .ciphertextBlob(SdkBytes.fromByteArray(encryptedKey.decode()))
@@ -164,5 +187,9 @@ public class KMSRSADecrypter implements JWEDecrypter {
     @Override
     public JWEJCAContext getJCAContext() {
         return jcaContext;
+    }
+
+    public boolean isKeyRotationEnabled() {
+        return keyRotationEnabled;
     }
 }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/KMSRSADecrypterTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/KMSRSADecrypterTest.java
@@ -56,6 +56,7 @@ class KMSRSADecrypterTest {
     @BeforeEach
     void setup() {
         environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "false");
+        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "false");
     }
 
     @Test
@@ -238,8 +239,11 @@ class KMSRSADecrypterTest {
     }
 
     @Test
-    void shouldThrowExceptionWhenAllKeyAliasesAreNotPresent() throws Exception {
+    void shouldThrowExceptionWhenAllKeyAliasesAreNotPresentAndLegacyKeyFallBackIsNotEnabled()
+            throws Exception {
         environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
+        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "false");
+
         KMSRSADecrypter kmsRsaDecrypter =
                 new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient, this.mockeventProbe);
         JWEHeader header = createHeader();
@@ -262,6 +266,96 @@ class KMSRSADecrypterTest {
                                 header, encryptedKey, iv, cipherText, authTag, AAD.compute(header)),
                 "Failed to decrypt with all available key aliases.");
         verify(mockKmsClient, times(3)).decrypt(any(DecryptRequest.class));
+        verify(mockeventProbe, times(1)).counterMetric(ALL_ALIASES_UNAVAILABLE);
+    }
+
+    @Test
+    void
+            shouldThrowExceptionWhenAllKeyAliasesAreNotPresentAndLegacyKeyFallBackIsEnabledAndLegacyKeyFallBackFails()
+                    throws Exception {
+        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
+        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "true");
+
+        KMSRSADecrypter kmsRsaDecrypter =
+                new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient, this.mockeventProbe);
+        JWEHeader header = createHeader();
+        Base64URL encryptedKey =
+                Base64URL.from(
+                        "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
+        Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
+        Base64URL cipherText =
+                Base64URL.from(
+                        "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
+        Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
+        when(mockKmsClient.decrypt(any(DecryptRequest.class)))
+                .thenThrow(new RuntimeException("primary key failed to decrypt"))
+                .thenThrow(new RuntimeException("secondary key failed to decrypt"))
+                .thenThrow(new RuntimeException("previous key failed to decrypt"))
+                .thenThrow(new RuntimeException("Failed to decrypt with legacy key.")); // fallback
+
+        assertThrows(
+                JOSEException.class,
+                () ->
+                        kmsRsaDecrypter.decrypt(
+                                header, encryptedKey, iv, cipherText, authTag, AAD.compute(header)),
+                "Failed to decrypt with legacy key.");
+        verify(mockKmsClient, times(4)).decrypt(any(DecryptRequest.class));
+        verify(mockeventProbe, times(1)).counterMetric(ALL_ALIASES_UNAVAILABLE);
+    }
+
+    @Test
+    void
+            shouldDecryptWhenAllKeyAliasesAreNotPresentAndLegacyKeyFallBackIsEnabledAndLegacyKeyFallBackSucceeds()
+                    throws Exception {
+        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
+        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "true");
+
+        KMSRSADecrypter kmsRsaDecrypter =
+                new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient, this.mockeventProbe);
+        JWEHeader header = createHeader();
+        Base64URL encryptedKey =
+                Base64URL.from(
+                        "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
+        Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
+        Base64URL cipherText =
+                Base64URL.from(
+                        "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
+        Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
+        DecryptResponse decryptResponse =
+                DecryptResponse.builder()
+                        .plaintext(
+                                SdkBytes.fromByteArray(
+                                        Base64.getDecoder()
+                                                .decode(
+                                                        "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
+                        .build();
+
+        when(mockKmsClient.decrypt(any(DecryptRequest.class)))
+                .thenThrow(new RuntimeException("primary key failed to decrypt"))
+                .thenThrow(new RuntimeException("secondary key failed to decrypt"))
+                .thenThrow(new RuntimeException("previous key failed to decrypt"))
+                .thenReturn(decryptResponse); // legacy fallback
+
+        byte[] result =
+                kmsRsaDecrypter.decrypt(
+                        header, encryptedKey, iv, cipherText, authTag, AAD.compute(header));
+        SignedJWT signedJWT = SignedJWT.parse(new String(result, StandardCharsets.UTF_8));
+        JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
+        ArgumentCaptor<DecryptRequest> decryptRequestArgumentCaptor =
+                ArgumentCaptor.forClass(DecryptRequest.class);
+        verify(mockKmsClient, times(4)).decrypt(decryptRequestArgumentCaptor.capture());
+        DecryptRequest actualDecryptRequest = decryptRequestArgumentCaptor.getValue();
+        assertEquals(
+                EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString(),
+                actualDecryptRequest.encryptionAlgorithmAsString());
+        assertEquals("test-key", actualDecryptRequest.keyId());
+        assertArrayEquals(
+                encryptedKey.decode(), actualDecryptRequest.ciphertextBlob().asByteArray());
+        assertEquals(11, claims.getClaims().size());
+        assertEquals("urn:uuid:8d097496-4410-49db-acdb-ffdca993fd2f", claims.getSubject());
+        assertEquals("ipv-core-stub", claims.getIssuer());
+
+        verify(mockKmsClient, times(4)).decrypt(any(DecryptRequest.class));
         verify(mockeventProbe, times(1)).counterMetric(ALL_ALIASES_UNAVAILABLE);
     }
 

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/KMSRSADecrypterTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/KMSRSADecrypterTest.java
@@ -8,6 +8,8 @@ import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -31,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -58,381 +61,431 @@ class KMSRSADecrypterTest {
         environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "false");
         environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "false");
     }
+    @Nested
+    @DisplayName("Focused on decryption when JWE parts / algorithm is invalid or valid")
+    class KMSRSADecryptWellFormedJWETest {
+        @Test
+        void shouldDecrypt() throws ParseException, JOSEException {
+            KMSRSADecrypter kmsRsaDecrypter =
+                    new KMSRSADecrypter(TEST_KEY_ID, mockKmsClient, mockeventProbe);
+            JWEHeader header = createHeader();
+            Base64URL encryptedKey =
+                    Base64URL.from(
+                            "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
+            Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
+            Base64URL cipherText =
+                    Base64URL.from(
+                            "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
+            Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
+            DecryptResponse decryptResponse =
+                    DecryptResponse.builder()
+                            .plaintext(
+                                    SdkBytes.fromByteArray(
+                                            Base64.getDecoder()
+                                                    .decode(
+                                                            "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
+                            .build();
+            when(mockKmsClient.decrypt(any(DecryptRequest.class))).thenReturn(decryptResponse);
+            byte[] result =
+                    kmsRsaDecrypter.decrypt(
+                            header, encryptedKey, iv, cipherText, authTag, AAD.compute(header));
+            SignedJWT signedJWT = SignedJWT.parse(new String(result, StandardCharsets.UTF_8));
+            JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
+            ArgumentCaptor<DecryptRequest> decryptRequestArgumentCaptor =
+                    ArgumentCaptor.forClass(DecryptRequest.class);
+            verify(mockKmsClient).decrypt(decryptRequestArgumentCaptor.capture());
+            DecryptRequest actualDecryptRequest = decryptRequestArgumentCaptor.getValue();
+            assertEquals(
+                    EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString(),
+                    actualDecryptRequest.encryptionAlgorithmAsString());
+            assertEquals(TEST_KEY_ID, actualDecryptRequest.keyId());
+            assertArrayEquals(
+                    encryptedKey.decode(), actualDecryptRequest.ciphertextBlob().asByteArray());
+            assertEquals(11, claims.getClaims().size());
+            assertEquals("urn:uuid:8d097496-4410-49db-acdb-ffdca993fd2f", claims.getSubject());
+            assertEquals("ipv-core-stub", claims.getIssuer());
+        }
 
-    @Test
-    void shouldDecrypt() throws ParseException, JOSEException {
-        KMSRSADecrypter kmsRsaDecrypter =
-                new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient, this.mockeventProbe);
-        JWEHeader header = createHeader();
-        Base64URL encryptedKey =
-                Base64URL.from(
-                        "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
-        Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
-        Base64URL cipherText =
-                Base64URL.from(
-                        "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
-        Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
-        DecryptResponse decryptResponse =
-                DecryptResponse.builder()
-                        .plaintext(
-                                SdkBytes.fromByteArray(
-                                        Base64.getDecoder()
-                                                .decode(
-                                                        "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
-                        .build();
-        when(mockKmsClient.decrypt(any(DecryptRequest.class))).thenReturn(decryptResponse);
-        byte[] result =
-                kmsRsaDecrypter.decrypt(
-                        header, encryptedKey, iv, cipherText, authTag, AAD.compute(header));
-        SignedJWT signedJWT = SignedJWT.parse(new String(result, StandardCharsets.UTF_8));
-        JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
-        ArgumentCaptor<DecryptRequest> decryptRequestArgumentCaptor =
-                ArgumentCaptor.forClass(DecryptRequest.class);
-        verify(mockKmsClient).decrypt(decryptRequestArgumentCaptor.capture());
-        DecryptRequest actualDecryptRequest = decryptRequestArgumentCaptor.getValue();
-        assertEquals(
-                EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString(),
-                actualDecryptRequest.encryptionAlgorithmAsString());
-        assertEquals(TEST_KEY_ID, actualDecryptRequest.keyId());
-        assertArrayEquals(
-                encryptedKey.decode(), actualDecryptRequest.ciphertextBlob().asByteArray());
-        assertEquals(11, claims.getClaims().size());
-        assertEquals("urn:uuid:8d097496-4410-49db-acdb-ffdca993fd2f", claims.getSubject());
-        assertEquals("ipv-core-stub", claims.getIssuer());
+        @Test
+        void shouldThrowExceptionWhenEncryptedKeyIsNull() throws ParseException {
+            KMSRSADecrypter kmsRsaDecrypter =
+                    new KMSRSADecrypter(TEST_KEY_ID, mockKmsClient, mockeventProbe);
+            JWEHeader header = createHeader();
+            Base64URL testBase64URL = Base64URL.from("esS");
+            assertThrows(
+                    JOSEException.class,
+                    () ->
+                            kmsRsaDecrypter.decrypt(
+                                    header,
+                                    null,
+                                    testBase64URL,
+                                    testBase64URL,
+                                    testBase64URL,
+                                    AAD.compute(header)),
+                    "Missing JWE encrypted key");
+        }
+
+        @Test
+        void shouldThrowExceptionWhenInitVectorIsNull() throws ParseException {
+            KMSRSADecrypter kmsRsaDecrypter =
+                    new KMSRSADecrypter(TEST_KEY_ID, mockKmsClient, mockeventProbe);
+            JWEHeader header = createHeader();
+            Base64URL testBase64URL = Base64URL.from("esS");
+            assertThrows(
+                    JOSEException.class,
+                    () ->
+                            kmsRsaDecrypter.decrypt(
+                                    header,
+                                    testBase64URL,
+                                    null,
+                                    testBase64URL,
+                                    testBase64URL,
+                                    AAD.compute(header)),
+                    "Missing JWE initialization vector (IV)");
+        }
+
+        @Test
+        void shouldThrowExceptionWhenAuthTagIsNull() throws ParseException {
+            KMSRSADecrypter kmsRsaDecrypter =
+                    new KMSRSADecrypter(TEST_KEY_ID, mockKmsClient, mockeventProbe);
+            JWEHeader header = createHeader();
+            Base64URL testBase64URL = Base64URL.from("esS");
+            assertThrows(
+                    JOSEException.class,
+                    () ->
+                            kmsRsaDecrypter.decrypt(
+                                    header,
+                                    testBase64URL,
+                                    testBase64URL,
+                                    testBase64URL,
+                                    null,
+                                    AAD.compute(header)),
+                    "Missing JWE authentication tag");
+        }
+
+        @Test
+        void shouldThrowExceptionWhenUnsupportedAlgorithmSupplied() throws ParseException {
+            KMSRSADecrypter kmsRsaDecrypter =
+                    new KMSRSADecrypter(TEST_KEY_ID, mockKmsClient, mockeventProbe);
+            JWEHeader header = createHeader(JWEAlgorithm.ECDH_1PU_A256KW);
+            Base64URL testBase64URL = Base64URL.from("esS");
+            assertThrows(
+                    JOSEException.class,
+                    () ->
+                            kmsRsaDecrypter.decrypt(
+                                    header,
+                                    testBase64URL,
+                                    testBase64URL,
+                                    testBase64URL,
+                                    testBase64URL,
+                                    AAD.compute(header)),
+                    "Unsupported JWE algorithm ECDH-1PU+A256KW, must be RSA-OAEP-256");
+        }
     }
+    @Nested
+    @DisplayName("Focused on the decryption when Key rotation flag is enabled and KMS aliases are used")
+    class KMSRSADecrypterUsingKmsAliasTest {
+        @Test
+        void shouldDecryptWithPrimaryAlias() throws ParseException, JOSEException {
+            environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
+            KMSRSADecrypter kmsRsaDecrypter =
+                    new KMSRSADecrypter(TEST_KEY_ID, mockKmsClient, mockeventProbe);
+            JWEHeader header = createHeader();
+            Base64URL encryptedKey =
+                    Base64URL.from(
+                            "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
+            Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
+            Base64URL cipherText =
+                    Base64URL.from(
+                            "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
+            Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
+            DecryptResponse decryptResponse =
+                    DecryptResponse.builder()
+                            .keyId(TEST_KEY_ID)
+                            .plaintext(
+                                    SdkBytes.fromByteArray(
+                                            Base64.getDecoder()
+                                                    .decode(
+                                                            "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
+                            .build();
+            when(mockKmsClient.decrypt(any(DecryptRequest.class))).thenReturn(decryptResponse);
+            byte[] result =
+                    kmsRsaDecrypter.decrypt(
+                            header, encryptedKey, iv, cipherText, authTag, AAD.compute(header));
+            SignedJWT signedJWT = SignedJWT.parse(new String(result, StandardCharsets.UTF_8));
+            JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
+            ArgumentCaptor<DecryptRequest> decryptRequestArgumentCaptor =
+                    ArgumentCaptor.forClass(DecryptRequest.class);
+            verify(mockKmsClient).decrypt(decryptRequestArgumentCaptor.capture());
+            DecryptRequest actualDecryptRequest = decryptRequestArgumentCaptor.getValue();
+            assertEquals(
+                    EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString(),
+                    actualDecryptRequest.encryptionAlgorithmAsString());
+            assertEquals("alias/" + SESSION_DECRYPTION_KEY_PRIMARY_ALIAS, actualDecryptRequest.keyId());
+            assertArrayEquals(
+                    encryptedKey.decode(), actualDecryptRequest.ciphertextBlob().asByteArray());
+            assertEquals(11, claims.getClaims().size());
+            assertEquals("urn:uuid:8d097496-4410-49db-acdb-ffdca993fd2f", claims.getSubject());
+            assertEquals("ipv-core-stub", claims.getIssuer());
+        }
 
-    @Test
-    void shouldDecryptWithPrimaryAlias() throws ParseException, JOSEException {
-        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
-        KMSRSADecrypter kmsRsaDecrypter =
-                new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient, this.mockeventProbe);
-        JWEHeader header = createHeader();
-        Base64URL encryptedKey =
-                Base64URL.from(
-                        "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
-        Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
-        Base64URL cipherText =
-                Base64URL.from(
-                        "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
-        Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
-        DecryptResponse decryptResponse =
-                DecryptResponse.builder()
-                        .keyId(TEST_KEY_ID)
-                        .plaintext(
-                                SdkBytes.fromByteArray(
-                                        Base64.getDecoder()
-                                                .decode(
-                                                        "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
-                        .build();
-        when(mockKmsClient.decrypt(any(DecryptRequest.class))).thenReturn(decryptResponse);
-        byte[] result =
-                kmsRsaDecrypter.decrypt(
-                        header, encryptedKey, iv, cipherText, authTag, AAD.compute(header));
-        SignedJWT signedJWT = SignedJWT.parse(new String(result, StandardCharsets.UTF_8));
-        JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
-        ArgumentCaptor<DecryptRequest> decryptRequestArgumentCaptor =
-                ArgumentCaptor.forClass(DecryptRequest.class);
-        verify(mockKmsClient).decrypt(decryptRequestArgumentCaptor.capture());
-        DecryptRequest actualDecryptRequest = decryptRequestArgumentCaptor.getValue();
-        assertEquals(
-                EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString(),
-                actualDecryptRequest.encryptionAlgorithmAsString());
-        assertEquals("alias/" + SESSION_DECRYPTION_KEY_PRIMARY_ALIAS, actualDecryptRequest.keyId());
-        assertArrayEquals(
-                encryptedKey.decode(), actualDecryptRequest.ciphertextBlob().asByteArray());
-        assertEquals(11, claims.getClaims().size());
-        assertEquals("urn:uuid:8d097496-4410-49db-acdb-ffdca993fd2f", claims.getSubject());
-        assertEquals("ipv-core-stub", claims.getIssuer());
+        @Test
+        void shouldDecryptWithSecondaryAlias() throws ParseException, JOSEException {
+            environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
+            KMSRSADecrypter kmsRsaDecrypter =
+                    new KMSRSADecrypter(TEST_KEY_ID, mockKmsClient, mockeventProbe);
+            JWEHeader header = createHeader();
+            Base64URL encryptedKey =
+                    Base64URL.from(
+                            "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
+            Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
+            Base64URL cipherText =
+                    Base64URL.from(
+                            "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
+            Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
+            DecryptResponse decryptResponse =
+                    DecryptResponse.builder()
+                            .plaintext(
+                                    SdkBytes.fromByteArray(
+                                            Base64.getDecoder()
+                                                    .decode(
+                                                            "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
+                            .build();
+            when(mockKmsClient.decrypt(any(DecryptRequest.class)))
+                    .thenThrow(new RuntimeException("primary key failed to decrypt"))
+                    .thenReturn(decryptResponse);
+            byte[] result =
+                    kmsRsaDecrypter.decrypt(
+                            header, encryptedKey, iv, cipherText, authTag, AAD.compute(header));
+            SignedJWT signedJWT = SignedJWT.parse(new String(result, StandardCharsets.UTF_8));
+            JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
+            ArgumentCaptor<DecryptRequest> decryptRequestArgumentCaptor =
+                    ArgumentCaptor.forClass(DecryptRequest.class);
+            verify(mockKmsClient, times(2)).decrypt(decryptRequestArgumentCaptor.capture());
+            DecryptRequest actualDecryptRequest = decryptRequestArgumentCaptor.getValue();
+            assertEquals(
+                    EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString(),
+                    actualDecryptRequest.encryptionAlgorithmAsString());
+            assertEquals(
+                    "alias/" + SESSION_DECRYPTION_KEY_SECONDARY_ALIAS, actualDecryptRequest.keyId());
+            assertArrayEquals(
+                    encryptedKey.decode(), actualDecryptRequest.ciphertextBlob().asByteArray());
+            assertEquals(11, claims.getClaims().size());
+            assertEquals("urn:uuid:8d097496-4410-49db-acdb-ffdca993fd2f", claims.getSubject());
+            assertEquals("ipv-core-stub", claims.getIssuer());
+        }
+
+        @Test
+        void shouldDecryptWithPreviousAlias() throws ParseException, JOSEException {
+            environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
+            KMSRSADecrypter kmsRsaDecrypter =
+                    new KMSRSADecrypter(TEST_KEY_ID, mockKmsClient, mockeventProbe);
+            JWEHeader header = createHeader();
+            Base64URL encryptedKey =
+                    Base64URL.from(
+                            "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
+            Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
+            Base64URL cipherText =
+                    Base64URL.from(
+                            "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
+            Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
+            DecryptResponse decryptResponse =
+                    DecryptResponse.builder()
+                            .plaintext(
+                                    SdkBytes.fromByteArray(
+                                            Base64.getDecoder()
+                                                    .decode(
+                                                            "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
+                            .build();
+            when(mockKmsClient.decrypt(any(DecryptRequest.class)))
+                    .thenThrow(new RuntimeException("primary key failed to decrypt"))
+                    .thenThrow(new RuntimeException("secondary key failed to decrypt"))
+                    .thenReturn(decryptResponse);
+            byte[] result =
+                    kmsRsaDecrypter.decrypt(
+                            header, encryptedKey, iv, cipherText, authTag, AAD.compute(header));
+            SignedJWT signedJWT = SignedJWT.parse(new String(result, StandardCharsets.UTF_8));
+            JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
+            ArgumentCaptor<DecryptRequest> decryptRequestArgumentCaptor =
+                    ArgumentCaptor.forClass(DecryptRequest.class);
+            verify(mockKmsClient, times(3)).decrypt(decryptRequestArgumentCaptor.capture());
+            DecryptRequest actualDecryptRequest = decryptRequestArgumentCaptor.getValue();
+            assertEquals(
+                    EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString(),
+                    actualDecryptRequest.encryptionAlgorithmAsString());
+            assertEquals(
+                    "alias/" + SESSION_DECRYPTION_KEY_PREVIOUS_ALIAS, actualDecryptRequest.keyId());
+            assertArrayEquals(
+                    encryptedKey.decode(), actualDecryptRequest.ciphertextBlob().asByteArray());
+            assertEquals(11, claims.getClaims().size());
+            assertEquals("urn:uuid:8d097496-4410-49db-acdb-ffdca993fd2f", claims.getSubject());
+            assertEquals("ipv-core-stub", claims.getIssuer());
+        }
     }
+    @Nested
+    @DisplayName("Focused on decryption when key rotation and legacy fall back flags are enabled")
+    class KMSRSADecrypterLegacyKeyFallbackTest {
+        @Test
+        @DisplayName("throws when all decryption attempts with aliases fail and the fail back legacy flag is disabled")
+        void shouldThrowWhenLegacyFallbackDisabledAndAllAliasesAreNotPresentOrFail()
+                throws Exception {
+            environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
+            environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "false");
 
-    @Test
-    void shouldDecryptWithSecondaryAlias() throws ParseException, JOSEException {
-        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
-        KMSRSADecrypter kmsRsaDecrypter =
-                new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient, this.mockeventProbe);
-        JWEHeader header = createHeader();
-        Base64URL encryptedKey =
-                Base64URL.from(
-                        "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
-        Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
-        Base64URL cipherText =
-                Base64URL.from(
-                        "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
-        Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
-        DecryptResponse decryptResponse =
-                DecryptResponse.builder()
-                        .plaintext(
-                                SdkBytes.fromByteArray(
-                                        Base64.getDecoder()
-                                                .decode(
-                                                        "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
-                        .build();
-        when(mockKmsClient.decrypt(any(DecryptRequest.class)))
-                .thenThrow(new RuntimeException("primary key failed to decrypt"))
-                .thenReturn(decryptResponse);
-        byte[] result =
-                kmsRsaDecrypter.decrypt(
-                        header, encryptedKey, iv, cipherText, authTag, AAD.compute(header));
-        SignedJWT signedJWT = SignedJWT.parse(new String(result, StandardCharsets.UTF_8));
-        JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
-        ArgumentCaptor<DecryptRequest> decryptRequestArgumentCaptor =
-                ArgumentCaptor.forClass(DecryptRequest.class);
-        verify(mockKmsClient, times(2)).decrypt(decryptRequestArgumentCaptor.capture());
-        DecryptRequest actualDecryptRequest = decryptRequestArgumentCaptor.getValue();
-        assertEquals(
-                EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString(),
-                actualDecryptRequest.encryptionAlgorithmAsString());
-        assertEquals(
-                "alias/" + SESSION_DECRYPTION_KEY_SECONDARY_ALIAS, actualDecryptRequest.keyId());
-        assertArrayEquals(
-                encryptedKey.decode(), actualDecryptRequest.ciphertextBlob().asByteArray());
-        assertEquals(11, claims.getClaims().size());
-        assertEquals("urn:uuid:8d097496-4410-49db-acdb-ffdca993fd2f", claims.getSubject());
-        assertEquals("ipv-core-stub", claims.getIssuer());
-    }
+            KMSRSADecrypter kmsRsaDecrypter =
+                    new KMSRSADecrypter(TEST_KEY_ID, mockKmsClient, mockeventProbe);
+            JWEHeader header = createHeader();
+            Base64URL encryptedKey =
+                    Base64URL.from(
+                            "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
+            Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
+            Base64URL cipherText =
+                    Base64URL.from(
+                            "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
+            Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
+            when(mockKmsClient.decrypt(any(DecryptRequest.class)))
+                    .thenThrow(new RuntimeException("primary key failed to decrypt"))
+                    .thenThrow(new RuntimeException("secondary key failed to decrypt"))
+                    .thenThrow(new RuntimeException("previous key failed to decrypt"));
+            assertThrows(
+                    JOSEException.class,
+                    () ->
+                            kmsRsaDecrypter.decrypt(
+                                    header, encryptedKey, iv, cipherText, authTag, AAD.compute(header)),
+                    "Failed to decrypt with all available key aliases.");
+            verify(mockKmsClient, times(3)).decrypt(any(DecryptRequest.class));
+            verify(mockeventProbe, times(1)).counterMetric(ALL_ALIASES_UNAVAILABLE);
+        }
 
-    @Test
-    void shouldDecryptWithPreviousAlias() throws ParseException, JOSEException {
-        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
-        KMSRSADecrypter kmsRsaDecrypter =
-                new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient, this.mockeventProbe);
-        JWEHeader header = createHeader();
-        Base64URL encryptedKey =
-                Base64URL.from(
-                        "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
-        Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
-        Base64URL cipherText =
-                Base64URL.from(
-                        "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
-        Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
-        DecryptResponse decryptResponse =
-                DecryptResponse.builder()
-                        .plaintext(
-                                SdkBytes.fromByteArray(
-                                        Base64.getDecoder()
-                                                .decode(
-                                                        "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
-                        .build();
-        when(mockKmsClient.decrypt(any(DecryptRequest.class)))
-                .thenThrow(new RuntimeException("primary key failed to decrypt"))
-                .thenThrow(new RuntimeException("secondary key failed to decrypt"))
-                .thenReturn(decryptResponse);
-        byte[] result =
-                kmsRsaDecrypter.decrypt(
-                        header, encryptedKey, iv, cipherText, authTag, AAD.compute(header));
-        SignedJWT signedJWT = SignedJWT.parse(new String(result, StandardCharsets.UTF_8));
-        JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
-        ArgumentCaptor<DecryptRequest> decryptRequestArgumentCaptor =
-                ArgumentCaptor.forClass(DecryptRequest.class);
-        verify(mockKmsClient, times(3)).decrypt(decryptRequestArgumentCaptor.capture());
-        DecryptRequest actualDecryptRequest = decryptRequestArgumentCaptor.getValue();
-        assertEquals(
-                EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString(),
-                actualDecryptRequest.encryptionAlgorithmAsString());
-        assertEquals(
-                "alias/" + SESSION_DECRYPTION_KEY_PREVIOUS_ALIAS, actualDecryptRequest.keyId());
-        assertArrayEquals(
-                encryptedKey.decode(), actualDecryptRequest.ciphertextBlob().asByteArray());
-        assertEquals(11, claims.getClaims().size());
-        assertEquals("urn:uuid:8d097496-4410-49db-acdb-ffdca993fd2f", claims.getSubject());
-        assertEquals("ipv-core-stub", claims.getIssuer());
-    }
+        @Test
+        @DisplayName("throws when all decryption attempts with aliases fail, but also fails decryption when legacy flag is enabled")
+        void shouldThrowWhenLegacyFallbackIsEnabledButDecryptionAlsoFails()
+                throws Exception {
+            environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
+            environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "true");
 
-    @Test
-    void shouldThrowExceptionWhenAllKeyAliasesAreNotPresentAndLegacyKeyFallBackIsNotEnabled()
-            throws Exception {
-        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
-        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "false");
+            KMSRSADecrypter kmsRsaDecrypter =
+                    new KMSRSADecrypter(TEST_KEY_ID, mockKmsClient, mockeventProbe);
+            JWEHeader header = createHeader();
+            Base64URL encryptedKey =
+                    Base64URL.from(
+                            "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
+            Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
+            Base64URL cipherText =
+                    Base64URL.from(
+                            "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
+            Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
+            when(mockKmsClient.decrypt(any(DecryptRequest.class)))
+                    .thenThrow(new RuntimeException("primary key failed to decrypt"))
+                    .thenThrow(new RuntimeException("secondary key failed to decrypt"))
+                    .thenThrow(new RuntimeException("previous key failed to decrypt"))
+                    .thenThrow(new RuntimeException("Failed to decrypt with legacy key.")); // fallback
 
-        KMSRSADecrypter kmsRsaDecrypter =
-                new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient, this.mockeventProbe);
-        JWEHeader header = createHeader();
-        Base64URL encryptedKey =
-                Base64URL.from(
-                        "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
-        Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
-        Base64URL cipherText =
-                Base64URL.from(
-                        "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
-        Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
-        when(mockKmsClient.decrypt(any(DecryptRequest.class)))
-                .thenThrow(new RuntimeException("primary key failed to decrypt"))
-                .thenThrow(new RuntimeException("secondary key failed to decrypt"))
-                .thenThrow(new RuntimeException("previous key failed to decrypt"));
-        assertThrows(
-                JOSEException.class,
-                () ->
-                        kmsRsaDecrypter.decrypt(
-                                header, encryptedKey, iv, cipherText, authTag, AAD.compute(header)),
-                "Failed to decrypt with all available key aliases.");
-        verify(mockKmsClient, times(3)).decrypt(any(DecryptRequest.class));
-        verify(mockeventProbe, times(1)).counterMetric(ALL_ALIASES_UNAVAILABLE);
-    }
+            assertThrows(
+                    JOSEException.class,
+                    () ->
+                            kmsRsaDecrypter.decrypt(
+                                    header, encryptedKey, iv, cipherText, authTag, AAD.compute(header)),
+                    "Failed to decrypt with legacy key.");
+            verify(mockKmsClient, times(4)).decrypt(any(DecryptRequest.class));
+            verify(mockeventProbe, times(1)).counterMetric(ALL_ALIASES_UNAVAILABLE);
+        }
 
-    @Test
-    void
-            shouldThrowExceptionWhenAllKeyAliasesAreNotPresentAndLegacyKeyFallBackIsEnabledAndLegacyKeyFallBackFails()
-                    throws Exception {
-        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
-        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "true");
+        @Test
+        @DisplayName("decrypts when all decryption attempts with aliases fail, but succeeds decryption when legacy flag is enabled")
+        void shouldDecryptWhenLegacyKeyFallBackIsEnabledAndLegacyKeyFallBackDecryptionSucceeds()
+                throws Exception {
+            environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
+            environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "true");
 
-        KMSRSADecrypter kmsRsaDecrypter =
-                new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient, this.mockeventProbe);
-        JWEHeader header = createHeader();
-        Base64URL encryptedKey =
-                Base64URL.from(
-                        "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
-        Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
-        Base64URL cipherText =
-                Base64URL.from(
-                        "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
-        Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
-        when(mockKmsClient.decrypt(any(DecryptRequest.class)))
-                .thenThrow(new RuntimeException("primary key failed to decrypt"))
-                .thenThrow(new RuntimeException("secondary key failed to decrypt"))
-                .thenThrow(new RuntimeException("previous key failed to decrypt"))
-                .thenThrow(new RuntimeException("Failed to decrypt with legacy key.")); // fallback
+            KMSRSADecrypter kmsRsaDecrypter =
+                    new KMSRSADecrypter(TEST_KEY_ID, mockKmsClient, mockeventProbe);
+            JWEHeader header = createHeader();
+            Base64URL encryptedKey =
+                    Base64URL.from(
+                            "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
+            Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
+            Base64URL cipherText =
+                    Base64URL.from(
+                            "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
+            Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
+            DecryptResponse decryptResponse =
+                    DecryptResponse.builder()
+                            .plaintext(
+                                    SdkBytes.fromByteArray(
+                                            Base64.getDecoder()
+                                                    .decode(
+                                                            "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
+                            .build();
 
-        assertThrows(
-                JOSEException.class,
-                () ->
-                        kmsRsaDecrypter.decrypt(
-                                header, encryptedKey, iv, cipherText, authTag, AAD.compute(header)),
-                "Failed to decrypt with legacy key.");
-        verify(mockKmsClient, times(4)).decrypt(any(DecryptRequest.class));
-        verify(mockeventProbe, times(1)).counterMetric(ALL_ALIASES_UNAVAILABLE);
-    }
+            when(mockKmsClient.decrypt(any(DecryptRequest.class)))
+                    .thenThrow(new RuntimeException("primary key failed to decrypt"))
+                    .thenThrow(new RuntimeException("secondary key failed to decrypt"))
+                    .thenThrow(new RuntimeException("previous key failed to decrypt"))
+                    .thenReturn(decryptResponse); // legacy fallback
 
-    @Test
-    void
-            shouldDecryptWhenAllKeyAliasesAreNotPresentAndLegacyKeyFallBackIsEnabledAndLegacyKeyFallBackSucceeds()
-                    throws Exception {
-        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
-        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "true");
+            byte[] result =
+                    kmsRsaDecrypter.decrypt(
+                            header, encryptedKey, iv, cipherText, authTag, AAD.compute(header));
+            SignedJWT signedJWT = SignedJWT.parse(new String(result, StandardCharsets.UTF_8));
+            JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
+            ArgumentCaptor<DecryptRequest> decryptRequestArgumentCaptor =
+                    ArgumentCaptor.forClass(DecryptRequest.class);
+            verify(mockKmsClient, times(4)).decrypt(decryptRequestArgumentCaptor.capture());
+            DecryptRequest actualDecryptRequest = decryptRequestArgumentCaptor.getValue();
+            assertEquals(
+                    EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString(),
+                    actualDecryptRequest.encryptionAlgorithmAsString());
+            assertEquals("test-key", actualDecryptRequest.keyId());
+            assertArrayEquals(
+                    encryptedKey.decode(), actualDecryptRequest.ciphertextBlob().asByteArray());
+            assertEquals(11, claims.getClaims().size());
+            assertEquals("urn:uuid:8d097496-4410-49db-acdb-ffdca993fd2f", claims.getSubject());
+            assertEquals("ipv-core-stub", claims.getIssuer());
 
-        KMSRSADecrypter kmsRsaDecrypter =
-                new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient, this.mockeventProbe);
-        JWEHeader header = createHeader();
-        Base64URL encryptedKey =
-                Base64URL.from(
-                        "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
-        Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
-        Base64URL cipherText =
-                Base64URL.from(
-                        "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
-        Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
-        DecryptResponse decryptResponse =
-                DecryptResponse.builder()
-                        .plaintext(
-                                SdkBytes.fromByteArray(
-                                        Base64.getDecoder()
-                                                .decode(
-                                                        "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
-                        .build();
+            verify(mockKmsClient, times(4)).decrypt(any(DecryptRequest.class));
+            verify(mockeventProbe, times(1)).counterMetric(ALL_ALIASES_UNAVAILABLE);
+        }
+        @Test
+        @DisplayName("succeeds with second alias and skips legacy fallback even when enabled")
+        void shouldNotAttemptLegacyFallbackWhenAliasSucceeds() throws Exception {
+            environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
+            environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "true");
 
-        when(mockKmsClient.decrypt(any(DecryptRequest.class)))
-                .thenThrow(new RuntimeException("primary key failed to decrypt"))
-                .thenThrow(new RuntimeException("secondary key failed to decrypt"))
-                .thenThrow(new RuntimeException("previous key failed to decrypt"))
-                .thenReturn(decryptResponse); // legacy fallback
+            KMSRSADecrypter kmsRsaDecrypter =
+                    new KMSRSADecrypter(TEST_KEY_ID, mockKmsClient, mockeventProbe);
+            JWEHeader header = createHeader();
+            Base64URL encryptedKey =
+                    Base64URL.from(
+                            "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
+            Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
+            Base64URL cipherText =
+                    Base64URL.from(
+                            "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
+            Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
 
-        byte[] result =
-                kmsRsaDecrypter.decrypt(
-                        header, encryptedKey, iv, cipherText, authTag, AAD.compute(header));
-        SignedJWT signedJWT = SignedJWT.parse(new String(result, StandardCharsets.UTF_8));
-        JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
-        ArgumentCaptor<DecryptRequest> decryptRequestArgumentCaptor =
-                ArgumentCaptor.forClass(DecryptRequest.class);
-        verify(mockKmsClient, times(4)).decrypt(decryptRequestArgumentCaptor.capture());
-        DecryptRequest actualDecryptRequest = decryptRequestArgumentCaptor.getValue();
-        assertEquals(
-                EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString(),
-                actualDecryptRequest.encryptionAlgorithmAsString());
-        assertEquals("test-key", actualDecryptRequest.keyId());
-        assertArrayEquals(
-                encryptedKey.decode(), actualDecryptRequest.ciphertextBlob().asByteArray());
-        assertEquals(11, claims.getClaims().size());
-        assertEquals("urn:uuid:8d097496-4410-49db-acdb-ffdca993fd2f", claims.getSubject());
-        assertEquals("ipv-core-stub", claims.getIssuer());
+            when(mockKmsClient.decrypt(any(DecryptRequest.class)))
+                    .thenThrow(new RuntimeException("primary key failed"))
+                    .thenReturn(
+                            DecryptResponse.builder()
+                                    .plaintext(
+                                            SdkBytes.fromByteArray(
+                                                    Base64.getDecoder().decode(
+                                                            "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
+                                    .build());
 
-        verify(mockKmsClient, times(4)).decrypt(any(DecryptRequest.class));
-        verify(mockeventProbe, times(1)).counterMetric(ALL_ALIASES_UNAVAILABLE);
-    }
+            byte[] result =
+                    kmsRsaDecrypter.decrypt(
+                            header, encryptedKey, iv, cipherText, authTag, AAD.compute(header));
+            SignedJWT signedJWT = SignedJWT.parse(new String(result, StandardCharsets.UTF_8));
+            JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
 
-    @Test
-    void shouldThrowExceptionWhenEncryptedKeyIsNull() throws ParseException {
-        KMSRSADecrypter kmsRsaDecrypter =
-                new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient, this.mockeventProbe);
-        JWEHeader header = createHeader();
-        Base64URL testBase64URL = Base64URL.from("esS");
-        assertThrows(
-                JOSEException.class,
-                () ->
-                        kmsRsaDecrypter.decrypt(
-                                header,
-                                null,
-                                testBase64URL,
-                                testBase64URL,
-                                testBase64URL,
-                                AAD.compute(header)),
-                "Missing JWE encrypted key");
-    }
+            assertEquals("urn:uuid:8d097496-4410-49db-acdb-ffdca993fd2f", claims.getSubject());
+            assertEquals("ipv-core-stub", claims.getIssuer());
 
-    @Test
-    void shouldThrowExceptionWhenInitVectorIsNull() throws ParseException {
-        KMSRSADecrypter kmsRsaDecrypter =
-                new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient, this.mockeventProbe);
-        JWEHeader header = createHeader();
-        Base64URL testBase64URL = Base64URL.from("esS");
-        assertThrows(
-                JOSEException.class,
-                () ->
-                        kmsRsaDecrypter.decrypt(
-                                header,
-                                testBase64URL,
-                                null,
-                                testBase64URL,
-                                testBase64URL,
-                                AAD.compute(header)),
-                "Missing JWE initialization vector (IV)");
-    }
-
-    @Test
-    void shouldThrowExceptionWhenAuthTagIsNull() throws ParseException {
-        KMSRSADecrypter kmsRsaDecrypter =
-                new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient, this.mockeventProbe);
-        JWEHeader header = createHeader();
-        Base64URL testBase64URL = Base64URL.from("esS");
-        assertThrows(
-                JOSEException.class,
-                () ->
-                        kmsRsaDecrypter.decrypt(
-                                header,
-                                testBase64URL,
-                                testBase64URL,
-                                testBase64URL,
-                                null,
-                                AAD.compute(header)),
-                "Missing JWE authentication tag");
-    }
-
-    @Test
-    void shouldThrowExceptionWhenUnsupportedAlgorithmSupplied() throws ParseException {
-        KMSRSADecrypter kmsRsaDecrypter =
-                new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient, this.mockeventProbe);
-        JWEHeader header = createHeader(JWEAlgorithm.ECDH_1PU_A256KW);
-        Base64URL testBase64URL = Base64URL.from("esS");
-        assertThrows(
-                JOSEException.class,
-                () ->
-                        kmsRsaDecrypter.decrypt(
-                                header,
-                                testBase64URL,
-                                testBase64URL,
-                                testBase64URL,
-                                testBase64URL,
-                                AAD.compute(header)),
-                "Unsupported JWE algorithm ECDH-1PU+A256KW, must be RSA-OAEP-256");
+            verify(mockKmsClient, times(2)).decrypt(any(DecryptRequest.class));
+            verify(mockeventProbe, never()).counterMetric(ALL_ALIASES_UNAVAILABLE);
+        }
     }
 
     private JWEHeader createHeader() throws ParseException {

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/KMSRSADecrypterTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/KMSRSADecrypterTest.java
@@ -61,6 +61,7 @@ class KMSRSADecrypterTest {
         environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "false");
         environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "false");
     }
+
     @Nested
     @DisplayName("Focused on decryption when JWE parts / algorithm is invalid or valid")
     class KMSRSADecryptWellFormedJWETest {
@@ -182,8 +183,10 @@ class KMSRSADecrypterTest {
                     "Unsupported JWE algorithm ECDH-1PU+A256KW, must be RSA-OAEP-256");
         }
     }
+
     @Nested
-    @DisplayName("Focused on the decryption when Key rotation flag is enabled and KMS aliases are used")
+    @DisplayName(
+            "Focused on the decryption when Key rotation flag is enabled and KMS aliases are used")
     class KMSRSADecrypterUsingKmsAliasTest {
         @Test
         void shouldDecryptWithPrimaryAlias() throws ParseException, JOSEException {
@@ -221,7 +224,8 @@ class KMSRSADecrypterTest {
             assertEquals(
                     EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString(),
                     actualDecryptRequest.encryptionAlgorithmAsString());
-            assertEquals("alias/" + SESSION_DECRYPTION_KEY_PRIMARY_ALIAS, actualDecryptRequest.keyId());
+            assertEquals(
+                    "alias/" + SESSION_DECRYPTION_KEY_PRIMARY_ALIAS, actualDecryptRequest.keyId());
             assertArrayEquals(
                     encryptedKey.decode(), actualDecryptRequest.ciphertextBlob().asByteArray());
             assertEquals(11, claims.getClaims().size());
@@ -267,7 +271,8 @@ class KMSRSADecrypterTest {
                     EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString(),
                     actualDecryptRequest.encryptionAlgorithmAsString());
             assertEquals(
-                    "alias/" + SESSION_DECRYPTION_KEY_SECONDARY_ALIAS, actualDecryptRequest.keyId());
+                    "alias/" + SESSION_DECRYPTION_KEY_SECONDARY_ALIAS,
+                    actualDecryptRequest.keyId());
             assertArrayEquals(
                     encryptedKey.decode(), actualDecryptRequest.ciphertextBlob().asByteArray());
             assertEquals(11, claims.getClaims().size());
@@ -322,15 +327,18 @@ class KMSRSADecrypterTest {
             assertEquals("ipv-core-stub", claims.getIssuer());
         }
     }
+
     @Nested
     @DisplayName("Focused on decryption when key rotation and legacy fall back flags are enabled")
     class KMSRSADecrypterLegacyKeyFallbackTest {
         @Test
-        @DisplayName("throws when all decryption attempts with aliases fail and the fail back legacy flag is disabled")
+        @DisplayName(
+                "throws when all decryption attempts with aliases fail and the fail back legacy flag is disabled")
         void shouldThrowWhenLegacyFallbackDisabledAndAllAliasesAreNotPresentOrFail()
                 throws Exception {
             environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
-            environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "false");
+            environmentVariables.set(
+                    "ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "false");
 
             KMSRSADecrypter kmsRsaDecrypter =
                     new KMSRSADecrypter(TEST_KEY_ID, mockKmsClient, mockeventProbe);
@@ -351,18 +359,24 @@ class KMSRSADecrypterTest {
                     JOSEException.class,
                     () ->
                             kmsRsaDecrypter.decrypt(
-                                    header, encryptedKey, iv, cipherText, authTag, AAD.compute(header)),
+                                    header,
+                                    encryptedKey,
+                                    iv,
+                                    cipherText,
+                                    authTag,
+                                    AAD.compute(header)),
                     "Failed to decrypt with all available key aliases.");
             verify(mockKmsClient, times(3)).decrypt(any(DecryptRequest.class));
             verify(mockeventProbe, times(1)).counterMetric(ALL_ALIASES_UNAVAILABLE);
         }
 
         @Test
-        @DisplayName("throws when all decryption attempts with aliases fail, but also fails decryption when legacy flag is enabled")
-        void shouldThrowWhenLegacyFallbackIsEnabledButDecryptionAlsoFails()
-                throws Exception {
+        @DisplayName(
+                "throws when all decryption attempts with aliases fail, but also fails decryption when legacy flag is enabled")
+        void shouldThrowWhenLegacyFallbackIsEnabledButDecryptionAlsoFails() throws Exception {
             environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
-            environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "true");
+            environmentVariables.set(
+                    "ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "true");
 
             KMSRSADecrypter kmsRsaDecrypter =
                     new KMSRSADecrypter(TEST_KEY_ID, mockKmsClient, mockeventProbe);
@@ -379,24 +393,32 @@ class KMSRSADecrypterTest {
                     .thenThrow(new RuntimeException("primary key failed to decrypt"))
                     .thenThrow(new RuntimeException("secondary key failed to decrypt"))
                     .thenThrow(new RuntimeException("previous key failed to decrypt"))
-                    .thenThrow(new RuntimeException("Failed to decrypt with legacy key.")); // fallback
+                    .thenThrow(
+                            new RuntimeException("Failed to decrypt with legacy key.")); // fallback
 
             assertThrows(
                     JOSEException.class,
                     () ->
                             kmsRsaDecrypter.decrypt(
-                                    header, encryptedKey, iv, cipherText, authTag, AAD.compute(header)),
+                                    header,
+                                    encryptedKey,
+                                    iv,
+                                    cipherText,
+                                    authTag,
+                                    AAD.compute(header)),
                     "Failed to decrypt with legacy key.");
             verify(mockKmsClient, times(4)).decrypt(any(DecryptRequest.class));
             verify(mockeventProbe, times(1)).counterMetric(ALL_ALIASES_UNAVAILABLE);
         }
 
         @Test
-        @DisplayName("decrypts when all decryption attempts with aliases fail, but succeeds decryption when legacy flag is enabled")
+        @DisplayName(
+                "decrypts when all decryption attempts with aliases fail, but succeeds decryption when legacy flag is enabled")
         void shouldDecryptWhenLegacyKeyFallBackIsEnabledAndLegacyKeyFallBackDecryptionSucceeds()
                 throws Exception {
             environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
-            environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "true");
+            environmentVariables.set(
+                    "ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "true");
 
             KMSRSADecrypter kmsRsaDecrypter =
                     new KMSRSADecrypter(TEST_KEY_ID, mockKmsClient, mockeventProbe);
@@ -446,11 +468,13 @@ class KMSRSADecrypterTest {
             verify(mockKmsClient, times(4)).decrypt(any(DecryptRequest.class));
             verify(mockeventProbe, times(1)).counterMetric(ALL_ALIASES_UNAVAILABLE);
         }
+
         @Test
         @DisplayName("succeeds with second alias and skips legacy fallback even when enabled")
         void shouldNotAttemptLegacyFallbackWhenAliasSucceeds() throws Exception {
             environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
-            environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "true");
+            environmentVariables.set(
+                    "ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "true");
 
             KMSRSADecrypter kmsRsaDecrypter =
                     new KMSRSADecrypter(TEST_KEY_ID, mockKmsClient, mockeventProbe);
@@ -470,8 +494,9 @@ class KMSRSADecrypterTest {
                             DecryptResponse.builder()
                                     .plaintext(
                                             SdkBytes.fromByteArray(
-                                                    Base64.getDecoder().decode(
-                                                            "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
+                                                    Base64.getDecoder()
+                                                            .decode(
+                                                                    "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
                                     .build());
 
             byte[] result =

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/WellKnownJwksSteps.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/WellKnownJwksSteps.java
@@ -151,14 +151,15 @@ public class WellKnownJwksSteps {
                 is(true));
     }
 
-    @And("the feature flag is {string}")
-    public void feature_flag(String value) {
+    @And("the key rotation feature flag {string} and legacy fallback flag is {string}")
+    public void feature_flag(String enabled, String disabled) {
         setKmsRsaDecrypter(
                 new KMSRSADecrypter(
                         new ClientProviderFactory().getKMSClient(),
                         new EventProbe(),
                         authEncryptionKeyId,
-                        value.equalsIgnoreCase("enabled") ? true : false));
+                        enabled.equalsIgnoreCase("enabled") ? true : false,
+                        disabled.equalsIgnoreCase("disabled") ? true : false));
 
         setJwtDecrypter(new JWTDecrypter(getKmsrsaDecrypter()));
     }


### PR DESCRIPTION
## Proposed changes

Update KMSRSADecrypter 

### What changed

KMSRSADecrypter in common lambda has legacy flag updates

### Why did it change

So that eventually we have just one copy i.e. the one in the library, which common-lambda can reference

- [OJ-3210:](https://govukverify.atlassian.net/browse/OJ-3210)

## Checklists

### Environment variables or secrets


### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks