### PR TITLE
OJ-3412: Add new step to assert new public JWK alg

### DIFF
--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/WellKnownJwksSteps.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/WellKnownJwksSteps.java
@@ -101,9 +101,23 @@ public class WellKnownJwksSteps {
                                 .build()));
     }
 
+    /**
+     * @deprecated Use step "the response from the endpoint contains the public JWK keyset" instead.
+     */
+    @Deprecated
     @Then("the response from the endpoint includes the public JWK keyset")
     public void the_response_from_the_endpoint_includes_the_public_jwk_keyset()
             throws JsonProcessingException {
+        assertResponseContainsPublicJWKKeyset("RSA_OAEP_256");
+    }
+
+    @Then("the response from the endpoint contains the public JWK keyset")
+    public void the_response_from_the_endpoint_contains_the_public_jwk_keyset()
+            throws JsonProcessingException {
+        assertResponseContainsPublicJWKKeyset("RSA-OAEP-256");
+    }
+
+    private void assertResponseContainsPublicJWKKeyset(String alg) throws JsonProcessingException {
 
         JsonNode jwkResponse = objectMapper.readTree(httpResponse.getResponse().body());
 
@@ -116,7 +130,7 @@ public class WellKnownJwksSteps {
 
         assertThat(firstKey.get("kty").asText(), is("RSA"));
         assertThat(firstKey.get("use").asText(), is("enc"));
-        assertThat(firstKey.get("alg").asText(), is("RSA_OAEP_256"));
+        assertThat(firstKey.get("alg").asText(), is(alg));
     }
 
     @And("each key has an associated kid")


### PR DESCRIPTION
## Proposed changes

### What changed

Added a new step to assert new public JWK alg and deprecated the old step. The deprecated step can be removed in the next major release.

This changes the alg assert from `RSA_OAEP_256` to `RSA-OAEP-256`

### Why did it change

https://github.com/govuk-one-login/identity-key-rotation/pull/231

### Issue tracking

- [OJ-3412](https://govukverify.atlassian.net/browse/OJ-3412)

[OJ-3412]: https://govukverify.atlassian.net/browse/OJ-3412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ