### PR TITLE
OJ-3617: Bump powertools & increment CRI Lib version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // Important: see README on publishing a new version to Maven
-def buildVersion = "8.3.3"
+def buildVersion = "8.3.4"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 
@@ -28,20 +28,6 @@ configurations.configureEach {
 	// https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
 	exclude group:"software.amazon.awssdk", module: "apache-client"
 	exclude group:"software.amazon.awssdk", module: "netty-nio-client"
-}
-
-configurations.configureEach {
-	// Version 2.20.1 is required by latest powertools at time of writing (2.9.0) but affected by GHSA-72hv-8253-57qq
-	resolutionStrategy.eachDependency { details ->
-		if (details.requested.group == 'com.fasterxml.jackson.core' &&
-				details.requested.name == 'jackson-core') {
-
-			def requestedVersion = details.requested.version
-			if (requestedVersion == null || requestedVersion < '2.21.1') {
-				details.useVersion '2.21.1'
-			}
-		}
-	}
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 aws_sdk_version = "2.41.25"
 aws_lambda_events_version = "3.11.6"
 aspectjrt_version = "1.9.20.1"
-aws_powertools_version = "2.9.0"
+aws_powertools_version = "2.10.0"
 jackson_version = "2.21.1"
 jackson_annotations_version = "2.21" # annotations has no patch number
 nimbusds_oauth_version = "11.29.1"


### PR DESCRIPTION
## Proposed changes

### What changed

- Applied upgrade to latest version of powertools
- Removed jackson-core version override
- Bumped CRI Lib to v8.3.4

### Why did it change

- Final resolution for a vulnerability in jackson-core

### Issue tracking

- OJ-3617

### Testing

- Deployed inside a localdev address CRI following the instructions in the README
- Flow completed without issues

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks