### PR TITLE
chore: bump version to 8.3.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // Important: see README on publishing a new version to Maven
-def buildVersion = "8.3.4"
+def buildVersion = "8.3.5"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 


### PR DESCRIPTION
## Proposed changes

### What changed

Bump version to `8.3.5`

### Issue tracking

- [OJ-3679](https://govukverify.atlassian.net/browse/OJ-3679)

[OJ-3679]: https://govukverify.atlassian.net/browse/OJ-3679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ