### PR TITLE
[IPS-2341] Change CODEOWNERS from ID-SRE to REX

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @govuk-one-login/cri-orange-team @govuk-one-login/cri-orange-admins @govuk-one-login/cri-lime-team-leads @govuk-one-login/cri-lime-team-admins @govuk-one-login/identity-sre # Team ownership with break-glass overrides
+* @govuk-one-login/cri-orange-team @govuk-one-login/cri-orange-admins @govuk-one-login/cri-lime-team-leads @govuk-one-login/cri-lime-team-admins @govuk-one-login/reliability-engineering-x # Team ownership with break-glass overrides


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Changing CODEOWNERS from IDSRE to REX

### What changed

CODEOWNERS were changed from @govuk-one-login/identity-sre to @govuk-one-login/reliability-engineering-x

### Why did it change

Identity SRE have become a cross cutting SRE team under a new name, this changes the ownership from the old team to the new team

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-2341](https://govukverify.atlassian.net/browse/IPS-2341)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[IPS-2341]: https://govukverify.atlassian.net/browse/IPS-2341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ