### PR TITLE
OJ-3391: Remove Unused Feature Flags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // Important: see README on publishing a new version to Maven
-def buildVersion = "8.3.5"
+def buildVersion = "9.0.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilder.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilder.java
@@ -15,11 +15,6 @@ import java.util.UUID;
 
 public class VerifiableCredentialClaimsSetBuilder {
 
-    public static final String ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED =
-            "ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED";
-    public static final String ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID =
-            "ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID";
-
     private final ConfigurationService configurationService;
     private final Clock clock;
 
@@ -28,7 +23,6 @@ public class VerifiableCredentialClaimsSetBuilder {
     private String[] contexts;
     private String subject;
     private Object evidence;
-    private ChronoUnit ttlUnit;
     private long ttl;
     private JWTClaimsSet.Builder jwtClaimsSetBuilder;
 
@@ -47,7 +41,7 @@ public class VerifiableCredentialClaimsSetBuilder {
     }
 
     public VerifiableCredentialClaimsSetBuilder timeToLive(long ttl, ChronoUnit ttlUnit) {
-        this.ttlUnit = Objects.requireNonNull(ttlUnit, "ttlUnit must not be null");
+        Objects.requireNonNull(ttlUnit, "ttlUnit must not be null");
         if (ttl < 1L) {
             throw new IllegalArgumentException("ttl must be greater than zero");
         }
@@ -108,17 +102,11 @@ public class VerifiableCredentialClaimsSetBuilder {
                         .issuer(issuer)
                         .claim(JWTClaimNames.NOT_BEFORE, dateTimeNow.toEpochSecond());
 
-        if (!isReleaseFlag(ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED)) {
-            builder.claim(JWTClaimNames.EXPIRATION_TIME, getExpirationTimestamp(dateTimeNow));
-        }
-
         Map<String, Object> verifiableCredentialClaims = new LinkedHashMap<>();
         verifiableCredentialClaims.put(
                 "type", new String[] {"VerifiableCredential", this.verifiableCredentialType});
 
-        if (isReleaseFlag(ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID)) {
-            builder.claim(JWTClaimNames.JWT_ID, generateUniqueId());
-        }
+        builder.claim(JWTClaimNames.JWT_ID, generateUniqueId());
 
         if (Objects.nonNull(this.contexts) && contexts.length > 0) {
             verifiableCredentialClaims.put("@context", contexts);
@@ -134,10 +122,7 @@ public class VerifiableCredentialClaimsSetBuilder {
     }
 
     public JWTClaimsSet.Builder overrideJti(String jti) {
-        if (System.getenv(ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID).equals("override")) {
-            return overrideJti().jwtID(jti);
-        }
-        return this.jwtClaimsSetBuilder;
+        return overrideJti().jwtID(jti);
     }
 
     private JWTClaimsSet.Builder overrideJti() {
@@ -145,30 +130,6 @@ public class VerifiableCredentialClaimsSetBuilder {
             this.jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
         }
         return this.jwtClaimsSetBuilder;
-    }
-
-    private boolean isReleaseFlag(String environmentVariable) {
-        return Boolean.parseBoolean(System.getenv(environmentVariable));
-    }
-
-    private long getExpirationTimestamp(OffsetDateTime dateTimeNow) {
-        switch (this.ttlUnit) {
-            case SECONDS:
-                return dateTimeNow.plusSeconds(this.ttl).toEpochSecond();
-            case MINUTES:
-                return dateTimeNow.plusMinutes(this.ttl).toEpochSecond();
-            case HOURS:
-                return dateTimeNow.plusHours(this.ttl).toEpochSecond();
-            case DAYS:
-                return dateTimeNow.plusDays(this.ttl).toEpochSecond();
-            case MONTHS:
-                return dateTimeNow.plusMonths(this.ttl).toEpochSecond();
-            case YEARS:
-                return dateTimeNow.plusYears(this.ttl).toEpochSecond();
-            default:
-                throw new IllegalStateException(
-                        "Unexpected time-to-live unit encountered: " + ttlUnit);
-        }
     }
 
     private String generateUniqueId() {

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilderTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilderTest.java
@@ -5,16 +5,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
-import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
-import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.text.ParseException;
@@ -26,7 +22,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
-import static com.nimbusds.jwt.JWTClaimNames.EXPIRATION_TIME;
 import static com.nimbusds.jwt.JWTClaimNames.NOT_BEFORE;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,8 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder.ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID;
-import static uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder.ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(SystemStubsExtension.class)
@@ -49,9 +42,6 @@ class VerifiableCredentialClaimsSetBuilderTest {
     private static final PersonIdentityDetailed TEST_PERSON_IDENTITY =
             mock(PersonIdentityDetailed.class);
 
-    // Needs to be created here
-    @SystemStub private EnvironmentVariables environmentVariables = new EnvironmentVariables();
-
     @Mock private ConfigurationService mockConfigurationService;
     private Clock clock;
     private VerifiableCredentialClaimsSetBuilder builder;
@@ -59,11 +49,6 @@ class VerifiableCredentialClaimsSetBuilderTest {
     @BeforeEach
     void setup() {
         clock = Clock.fixed(Instant.parse("2016-11-03T10:15:30Z"), ZoneId.of("UTC"));
-
-        // Defaults
-        environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED, null);
-        environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID, null);
-
         builder = new VerifiableCredentialClaimsSetBuilder(mockConfigurationService, clock);
     }
 
@@ -92,9 +77,6 @@ class VerifiableCredentialClaimsSetBuilderTest {
         assertEquals(TEST_SUBJECT, builtClaimSet.getSubject());
         assertEquals(TEST_ISSUER, builtClaimSet.getIssuer());
         assertEquals(this.clock.instant().getEpochSecond(), builtClaimSet.getLongClaim(NOT_BEFORE));
-        assertTrue(
-                builtClaimSet.getLongClaim(EXPIRATION_TIME)
-                        > this.clock.instant().getEpochSecond());
         assertEquals(
                 TEST_PERSON_IDENTITY,
                 builtClaimSet.getJSONObjectClaim("vc").get("credentialSubject"));
@@ -106,13 +88,8 @@ class VerifiableCredentialClaimsSetBuilderTest {
     }
 
     @ParameterizedTest
-    @NullSource
     @ValueSource(strings = {"", " ", "false", "anything"})
-    void shouldBuildVerifiableCredential(String expiryRemovedReleasedFlagValue)
-            throws ParseException {
-
-        environmentVariables.set(
-                ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED, expiryRemovedReleasedFlagValue);
+    void shouldBuildVerifiableCredential() throws ParseException {
         builder = new VerifiableCredentialClaimsSetBuilder(mockConfigurationService, clock);
 
         String[] testContexts = new String[] {"context1", "context2"};
@@ -137,9 +114,6 @@ class VerifiableCredentialClaimsSetBuilderTest {
         assertEquals(TEST_SUBJECT, builtClaimSet.getSubject());
         assertEquals(TEST_ISSUER, builtClaimSet.getIssuer());
         assertEquals(this.clock.instant().getEpochSecond(), builtClaimSet.getLongClaim(NOT_BEFORE));
-        assertTrue(
-                builtClaimSet.getLongClaim(EXPIRATION_TIME)
-                        > this.clock.instant().getEpochSecond());
         assertEquals(
                 TEST_PERSON_IDENTITY,
                 builtClaimSet.getJSONObjectClaim("vc").get("credentialSubject"));
@@ -154,7 +128,6 @@ class VerifiableCredentialClaimsSetBuilderTest {
     void shouldBuildVerifiableCredentialWithoutAnExpiryTime() throws ParseException {
         String[] testContexts = new String[] {"context1", "context2"};
 
-        environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED, true);
         builder = new VerifiableCredentialClaimsSetBuilder(mockConfigurationService, clock);
 
         Map<String, String> evidence =
@@ -185,58 +158,10 @@ class VerifiableCredentialClaimsSetBuilderTest {
                 (String[]) builtClaimSet.getJSONObjectClaim("vc").get("type"));
         assertEquals(testContexts, builtClaimSet.getJSONObjectClaim("vc").get("@context"));
         assertEquals(evidence, builtClaimSet.getJSONObjectClaim("vc").get("evidence"));
-
-        assertNull(builtClaimSet.getLongClaim(EXPIRATION_TIME));
     }
 
     @Test
-    void shouldOverrideJtiWhenContainUniqueIdIsFalse() {
-        environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID, "override");
-        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_ISSUER);
-
-        var claimsSetBuilder =
-                new VerifiableCredentialClaimsSetBuilder(mockConfigurationService, clock)
-                        .subject(TEST_SUBJECT)
-                        .timeToLive(1L, ChronoUnit.MONTHS)
-                        .verifiableCredentialType(TEST_VC_TYPE)
-                        .verifiableCredentialSubject(TEST_PERSON_IDENTITY);
-
-        var originalBuilder = claimsSetBuilder.build();
-
-        claimsSetBuilder.overrideJti("dummyJti");
-        claimsSetBuilder.build();
-
-        assertNotEquals(originalBuilder.getJWTID(), claimsSetBuilder.build().getJWTID());
-        assertEquals(null, originalBuilder.getJWTID());
-
-        assertEquals("dummyJti", claimsSetBuilder.build().getJWTID());
-    }
-
-    @Test
-    void cannotOverrideJtiWhenContainUniqueIdIsFalse() {
-        environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID, false);
-        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_ISSUER);
-
-        var claimsSetBuilder =
-                new VerifiableCredentialClaimsSetBuilder(mockConfigurationService, clock)
-                        .subject(TEST_SUBJECT)
-                        .timeToLive(1L, ChronoUnit.MONTHS)
-                        .verifiableCredentialType(TEST_VC_TYPE)
-                        .verifiableCredentialSubject(TEST_PERSON_IDENTITY);
-
-        var originalBuilder = claimsSetBuilder.build();
-
-        claimsSetBuilder.overrideJti("dummyJti");
-        claimsSetBuilder.build();
-
-        assertNull(claimsSetBuilder.build().getJWTID());
-        assertEquals(null, originalBuilder.getJWTID());
-        assertEquals(null, claimsSetBuilder.build().getJWTID());
-    }
-
-    @Test
-    void cannotOverrideJtiWhenContainUniqueIdIsTrue() {
-        environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID, true);
+    void cannotOverrideJtiWhenContainUniqueIdIsDefaultedToTrue() {
         when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_ISSUER);
 
         var claimsSetBuilder =
@@ -258,13 +183,10 @@ class VerifiableCredentialClaimsSetBuilderTest {
     }
 
     @ParameterizedTest
-    @NullSource
     @ValueSource(strings = {"", " ", "false", "anything"})
-    void shouldBuildVerifiableCredentialWhenVcContainsUniqueIdReleaseFlagIsNotSpecified(
-            String expiryRemovedReleasedFlagValue) throws ParseException {
+    void shouldBuildVerifiableCredentialWhenVcContainsUniqueIdReleaseFlagIsNotSpecified()
+            throws ParseException {
 
-        environmentVariables.set(
-                ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED, expiryRemovedReleasedFlagValue);
         builder = new VerifiableCredentialClaimsSetBuilder(mockConfigurationService, clock);
 
         String[] testContexts = new String[] {"context1", "context2"};
@@ -286,9 +208,6 @@ class VerifiableCredentialClaimsSetBuilderTest {
         assertEquals(TEST_SUBJECT, builtClaimSet.getSubject());
         assertEquals(TEST_ISSUER, builtClaimSet.getIssuer());
         assertEquals(this.clock.instant().getEpochSecond(), builtClaimSet.getLongClaim(NOT_BEFORE));
-        assertTrue(
-                builtClaimSet.getLongClaim(EXPIRATION_TIME)
-                        > this.clock.instant().getEpochSecond());
         assertEquals(
                 TEST_PERSON_IDENTITY,
                 builtClaimSet.getJSONObjectClaim("vc").get("credentialSubject"));
@@ -300,14 +219,9 @@ class VerifiableCredentialClaimsSetBuilderTest {
     }
 
     @ParameterizedTest
-    @NullSource
     @ValueSource(strings = {"", " ", "false", "anything"})
-    void shouldBuildVerifiableCredentialWhenVcContainsUniqueIdReleaseFlagIsSpecified(
-            String expiryRemovedReleasedFlagValue) throws ParseException {
+    void shouldBuildVerifiableCredentialWithoutFeatureFlags() throws ParseException {
 
-        environmentVariables.set(
-                ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED, expiryRemovedReleasedFlagValue);
-        environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID, true);
         builder = new VerifiableCredentialClaimsSetBuilder(mockConfigurationService, clock);
 
         String[] testContexts = new String[] {"context1", "context2"};
@@ -328,9 +242,6 @@ class VerifiableCredentialClaimsSetBuilderTest {
         assertEquals(TEST_SUBJECT, builtClaimSet.getSubject());
         assertEquals(TEST_ISSUER, builtClaimSet.getIssuer());
         assertEquals(this.clock.instant().getEpochSecond(), builtClaimSet.getLongClaim(NOT_BEFORE));
-        assertTrue(
-                builtClaimSet.getLongClaim(EXPIRATION_TIME)
-                        > this.clock.instant().getEpochSecond());
         assertEquals(
                 TEST_PERSON_IDENTITY,
                 builtClaimSet.getJSONObjectClaim("vc").get("credentialSubject"));
@@ -372,9 +283,6 @@ class VerifiableCredentialClaimsSetBuilderTest {
         assertEquals(TEST_SUBJECT, builtClaimSet.getSubject());
         assertEquals(TEST_ISSUER, builtClaimSet.getIssuer());
         assertEquals(this.clock.instant().getEpochSecond(), builtClaimSet.getLongClaim(NOT_BEFORE));
-        assertTrue(
-                builtClaimSet.getLongClaim(EXPIRATION_TIME)
-                        > this.clock.instant().getEpochSecond());
         assertEquals(
                 TEST_PERSON_IDENTITY,
                 builtClaimSet.getJSONObjectClaim("vc").get("credentialSubject"));
@@ -384,33 +292,6 @@ class VerifiableCredentialClaimsSetBuilderTest {
 
         assertNull(builtClaimSet.getJSONObjectClaim("vc").get("@context"));
         assertNull(builtClaimSet.getJSONObjectClaim("vc").get("evidence"));
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-        "66,SECONDS,2016-11-03T10:16:36Z",
-        "30,MINUTES,2016-11-03T10:45:30Z",
-        "4,HOURS,2016-11-03T14:15:30Z",
-        "2,DAYS,2016-11-05T10:15:30Z",
-        "1,MONTHS,2016-12-03T10:15:30Z",
-        "2,YEARS,2018-11-03T10:15:30Z"
-    })
-    void shouldBuildVerifiableCredentialWithAppropriateExpirationTime(
-            long ttl, ChronoUnit ttlUnit, String expectedExpirationTime) throws ParseException {
-
-        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_ISSUER);
-
-        JWTClaimsSet builtClaimSet =
-                this.builder
-                        .subject(TEST_SUBJECT)
-                        .timeToLive(ttl, ttlUnit)
-                        .verifiableCredentialType(TEST_VC_TYPE)
-                        .verifiableCredentialSubject(TEST_PERSON_IDENTITY)
-                        .build();
-
-        assertEquals(
-                builtClaimSet.getLongClaim(EXPIRATION_TIME),
-                Instant.parse(expectedExpirationTime).getEpochSecond());
     }
 
     @Test
@@ -532,19 +413,5 @@ class VerifiableCredentialClaimsSetBuilderTest {
                         NullPointerException.class,
                         () -> this.builder.verifiableCredentialEvidence(null));
         assertEquals("evidence must not be null", thrownException.getMessage());
-    }
-
-    @Test
-    void shouldThrowErrorWhenInvalidTimeToLiveUnitSupplied() {
-        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_ISSUER);
-        this.builder
-                .subject(TEST_SUBJECT)
-                .timeToLive(5L, ChronoUnit.MILLIS)
-                .verifiableCredentialType(TEST_VC_TYPE)
-                .verifiableCredentialSubject(TEST_PERSON_IDENTITY);
-        IllegalStateException thrownException =
-                assertThrows(IllegalStateException.class, () -> this.builder.build());
-        assertEquals(
-                "Unexpected time-to-live unit encountered: Millis", thrownException.getMessage());
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- Removed feature flag references of `ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED` and `ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID` and removed tests specifically testing when feature flag is false as it'll be defaulted to true now.
- Bumped to new major version as its a breaking change
- Since `exp` is no longer being used in the VC based on this [decision](https://github.com/govuk-one-login/architecture/blob/main/adr/0076-vc-lifetime.md)  removed the references within the VC Builder file and unit tests 

### Why did it change
We have two feature flags that are no longer being used so should be removed from the CRIs to reduce maintenance overhead.

### Issue tracking

- [OJ-3391](https://govukverify.atlassian.net/browse/OJ-3391)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-3391]: https://govukverify.atlassian.net/browse/OJ-3391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ