### PR TITLE
OJ-3391: fix - update override jti method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // Important: see README on publishing a new version to Maven
-def buildVersion = "9.1.1"
+def buildVersion = "9.1.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // Important: see README on publishing a new version to Maven
-def buildVersion = "9.0.1"
+def buildVersion = "9.1.1"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilder.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilder.java
@@ -22,6 +22,7 @@ public class VerifiableCredentialClaimsSetBuilder {
     private String verifiableCredentialType;
     private String[] contexts;
     private String subject;
+    private String jtiOverride;
     private Object evidence;
     private long ttl;
     private JWTClaimsSet.Builder jwtClaimsSetBuilder;
@@ -106,7 +107,9 @@ public class VerifiableCredentialClaimsSetBuilder {
         verifiableCredentialClaims.put(
                 "type", new String[] {"VerifiableCredential", this.verifiableCredentialType});
 
-        builder.claim(JWTClaimNames.JWT_ID, generateUniqueId());
+        builder.claim(
+                JWTClaimNames.JWT_ID,
+                Objects.requireNonNullElseGet(jtiOverride, this::generateUniqueId));
 
         if (Objects.nonNull(this.contexts) && contexts.length > 0) {
             verifiableCredentialClaims.put("@context", contexts);
@@ -121,8 +124,9 @@ public class VerifiableCredentialClaimsSetBuilder {
         return builder.build();
     }
 
-    public JWTClaimsSet.Builder overrideJti(String jti) {
-        return overrideJti().jwtID(jti);
+    public void overrideJti(String jti) {
+        this.jtiOverride = jti;
+        overrideJti();
     }
 
     private JWTClaimsSet.Builder overrideJti() {

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilderTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilderTest.java
@@ -191,8 +191,8 @@ class VerifiableCredentialClaimsSetBuilderTest {
         var originalBuilder = claimsSetBuilder.build();
 
         claimsSetBuilder.overrideJti("dummyJti");
-        claimsSetBuilder.build();
 
+        assertNotNull(originalBuilder.getJWTID());
         assertNotEquals(originalBuilder.getJWTID(), claimsSetBuilder.build().getJWTID());
         assertEquals("dummyJti", claimsSetBuilder.build().getJWTID());
     }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilderTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilderTest.java
@@ -161,7 +161,7 @@ class VerifiableCredentialClaimsSetBuilderTest {
     }
 
     @Test
-    void cannotOverrideJtiWhenContainUniqueIdIsDefaultedToTrue() {
+    void cannotOverrideJtiWhenOverrideJtiNotContainString() {
         when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_ISSUER);
 
         var claimsSetBuilder =
@@ -173,13 +173,28 @@ class VerifiableCredentialClaimsSetBuilderTest {
 
         var originalClaimsSet = claimsSetBuilder.build();
 
-        claimsSetBuilder.overrideJti("dummyJti");
-        var newClaimsSet = claimsSetBuilder.build();
-
-        assertNotEquals("dummyJti", newClaimsSet.getJWTID());
-        assertNotEquals(originalClaimsSet.getJWTID(), newClaimsSet.getJWTID());
+        assertNotEquals("dummyJti", originalClaimsSet.getJWTID());
         assertNotNull(originalClaimsSet.getJWTID());
-        assertNotNull(newClaimsSet.getJWTID());
+    }
+
+    @Test
+    void shouldOverrideJtiWhenOverrideJtiContainString() {
+        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_ISSUER);
+
+        var claimsSetBuilder =
+                new VerifiableCredentialClaimsSetBuilder(mockConfigurationService, clock)
+                        .subject(TEST_SUBJECT)
+                        .timeToLive(1L, ChronoUnit.MONTHS)
+                        .verifiableCredentialType(TEST_VC_TYPE)
+                        .verifiableCredentialSubject(TEST_PERSON_IDENTITY);
+
+        var originalBuilder = claimsSetBuilder.build();
+
+        claimsSetBuilder.overrideJti("dummyJti");
+        claimsSetBuilder.build();
+
+        assertNotEquals(originalBuilder.getJWTID(), claimsSetBuilder.build().getJWTID());
+        assertEquals("dummyJti", claimsSetBuilder.build().getJWTID());
     }
 
     @ParameterizedTest


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Due to this `builder.claim(JWTClaimNames.JWT_ID, generateUniqueId());` the pact test were failing because the overridejti was returning a real jti rather than the dummyjti. Have updated it now to check if theres a string value first to produce the dummy jti and if not return the actual jti instead
- Added and updated unit test to check if the overrideJti method will return the "dummyJti" if there is a string and the real jti if there's no string.

### Why did it change

The `overrideJti` method was returning the actual jti value rather than the "dummyjti" causing pact test failures.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3391](https://govukverify.atlassian.net/browse/OJ-3391)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-3391]: https://govukverify.atlassian.net/browse/OJ-3391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ