### PR TITLE
OJ-3697: Override jackson-databind version to v2.22.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,12 @@ java {
 }
 
 configurations.configureEach {
+	resolutionStrategy {
+		force 'com.fasterxml.jackson.core:jackson-databind:2.22.1'
+	}
+}
+
+configurations.configureEach {
 	// https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
 	exclude group:"software.amazon.awssdk", module: "apache-client"
 	exclude group:"software.amazon.awssdk", module: "netty-nio-client"

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // Important: see README on publishing a new version to Maven
-def buildVersion = "9.1.1"
+def buildVersion = "9.1.2"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Overrode jackson-databind version to v2.22.1
- Executed a patch bump, bringing CRI Lib to v9.1.2

### Why did it change

- https://github.com/govuk-one-login/ipv-cri-lib/security/dependabot/17
- https://github.com/govuk-one-login/ipv-cri-lib/security/dependabot/16
- https://github.com/govuk-one-login/ipv-cri-lib/security/dependabot/15
- https://github.com/govuk-one-login/ipv-cri-lib/security/dependabot/22
- https://github.com/govuk-one-login/ipv-cri-lib/security/dependabot/19
- https://github.com/govuk-one-login/ipv-cri-lib/security/dependabot/20
- https://github.com/govuk-one-login/ipv-cri-lib/security/dependabot/21
- https://github.com/govuk-one-login/ipv-cri-lib/security/dependabot/18

### Issue tracking

- OJ-3697

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks